### PR TITLE
feat: add --dry-run flag to preview changes without modifying files

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,6 +46,7 @@ func Main() {
 	monthSubfolders := flag.Bool("month-subfolders", false, "Create month subfolders (1-12) inside year folders")
 	flatten := flag.Bool("flatten", false, "Put all media files directly in the output folder without year/album subfolders")
 	restoreMOV := flag.Bool("restore-mov", false, "Restore .MOV file extension in case the Major Brand EXIF field says \"Apple QuickTime (.MOV/QT)\"")
+	dryRun := flag.Bool("dry-run", false, "Log what would be done without copying or modifying any files")
 
 	flag.Parse()
 
@@ -86,6 +87,7 @@ func Main() {
 		IgnoreAlbums:        *ignoreAlbums,
 		MonthSubfolders:     *monthSubfolders,
 		RestoreMOVExtension: *restoreMOV,
+		DryRun:              *dryRun,
 	}
 
 	go func() {

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -45,6 +45,7 @@ type ProcessOptions struct {
 	IgnoreAlbums        bool
 	Flatten             bool
 	RestoreMOVExtension bool // See issue #2
+	DryRun              bool
 }
 
 type FixerContext struct {
@@ -98,7 +99,7 @@ func Process(
 		return ctx.Err()
 	}
 
-	if options.WriteMetadata || options.RestoreMOVExtension {
+	if !options.DryRun && (options.WriteMetadata || options.RestoreMOVExtension) {
 		if err := InitializeExifTool(); err != nil {
 			Log(LoggerError, "Failed to initialize exiftool: %v", err)
 			return err
@@ -355,6 +356,18 @@ func CreateFixedFile(
 	destPath string,
 	isYearFolder bool,
 ) error {
+	if fixerCtx.Options.DryRun {
+		if fixerCtx.Options.UseSymlinks && !isYearFolder {
+			Log(LoggerInfo, "[dry-run] Would symlink %s -> %s", destPath, filePath)
+		} else {
+			Log(LoggerInfo, "[dry-run] Would copy %s -> %s", filePath, destPath)
+		}
+		if fixerCtx.Options.WriteMetadata && fileMetadataPath != "" {
+			Log(LoggerInfo, "[dry-run] Would apply metadata from %s", fileMetadataPath)
+		}
+		return nil
+	}
+
 	// Ensure output directory exists (create if not)
 	destDir := filepath.Dir(destPath)
 	if _, err := os.Stat(destDir); os.IsNotExist(err) {

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -50,6 +50,7 @@ func Main() {
 	var ignoreAlbums bool = false
 	var monthSubfolders bool = false
 	var restoreMOVExtension bool = false
+	var dryRun bool = false
 
 	progressLabel := widget.NewLabel("Ready to start")
 	progressLabel.Truncation = fyne.TextTruncateEllipsis
@@ -110,6 +111,11 @@ func Main() {
 		fmt.Println("restore MOV extension", restoreMOVExtension)
 	})
 
+	dryRunCheckbox := widget.NewCheck("Dry run (no changes)", func(value bool) {
+		dryRun = value
+		fmt.Println("dry run", dryRun)
+	})
+
 	// Fix conflicting options
 	updateCheckboxStates := func() {
 		setEnabled := func(cb *widget.Check, enabled bool) {
@@ -154,6 +160,7 @@ func Main() {
 		monthSubfoldersCheckbox.Disable()
 		flattenCheckbox.Disable()
 		restoreMOVExtensionCheckbox.Disable()
+		dryRunCheckbox.Disable()
 
 		fixer.Log(fixer.LoggerInfo, "Processing...")
 		progressBar.SetValue(0)
@@ -171,6 +178,7 @@ func Main() {
 			IgnoreAlbums:        ignoreAlbums,
 			MonthSubfolders:     monthSubfolders,
 			RestoreMOVExtension: restoreMOVExtension,
+			DryRun:              dryRun,
 		}
 		go func() {
 			if err := fixer.Process(ctx, inputPath, outputPath, progressCh, opts); err != nil {
@@ -232,10 +240,10 @@ func Main() {
 				outputButton.Enable()
 				startButton.Enable()
 
-				// Manually re-enable restoreMOVExtensionCheckbox and writeMetadataCheckbox
-				// since they are not affected by other checboxes in updateCheckboxStates
+				// Manually re-enable checkboxes not affected by updateCheckboxStates
 				restoreMOVExtensionCheckbox.Enable()
 				writeMetadataCheckbox.Enable()
+				dryRunCheckbox.Enable()
 				// Re-enable checboxes based on current states
 				updateCheckboxStates()
 			})
@@ -319,6 +327,7 @@ func Main() {
 		monthSubfoldersCheckbox,
 		flattenCheckbox,
 		restoreMOVExtensionCheckbox,
+		dryRunCheckbox,
 	)
 
 	StartCancelRow := container.NewGridWithColumns(2, startButton, cancelButton)


### PR DESCRIPTION
## Summary
- Adds a `--dry-run` CLI flag and GUI checkbox that logs what would be done (copy, symlink, metadata writes) without actually creating or modifying any files
- Skips ExifTool initialization during dry-run since no metadata writes are performed
- Useful for users with large takeout exports who want to preview the output structure before committing

## Changes
- `internal/fixer/fixer.go`: Added `DryRun` field to `ProcessOptions`, skip ExifTool init when dry-run, early return in `CreateFixedFile` with descriptive log messages
- `internal/cli/cli.go`: Added `--dry-run` flag
- `internal/gui/gui.go`: Added "Dry run (no changes)" checkbox, wired into disable/enable lifecycle

## Test plan
- [ ] Run CLI with `--dry-run --input <takeout> --output <dest>` and verify no files are created in the output directory
- [ ] Run CLI without `--dry-run` and verify normal behavior is unchanged
- [ ] Verify `[dry-run]` prefixed log messages appear for each file that would be processed
- [ ] Verify ExifTool is not required/initialized during dry-run
- [ ] Test GUI checkbox enables/disables correctly during processing

// ticktockbent