### PR TITLE
feat: add support for additional image and video formats

### DIFF
--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -80,19 +80,33 @@ func ClearCacheDir(dir string) {
 	delete(dirCache, dir)
 }
 
-// All media extension to differ between media files and other files
+// All media extensions to differentiate between media files and other files
 var imageExtensions = map[string]struct{}{
 	".jpg":  {},
 	".jpeg": {},
 	".png":  {},
 	".heic": {},
+	".webp": {},
+	".gif":  {},
+	".tiff": {},
+	".tif":  {},
+	".bmp":  {},
+	// RAW formats
+	".cr2": {},
+	".nef": {},
+	".arw": {},
+	".dng": {},
+	".rw2": {},
 }
 
 var videoExtensions = map[string]struct{}{
-	".mp4": {},
-	".mov": {},
-	".avi": {},
-	".mkv": {},
+	".mp4":  {},
+	".mov":  {},
+	".avi":  {},
+	".mkv":  {},
+	".webm": {},
+	".m4v":  {},
+	".3gp":  {},
 }
 
 // Checks whether a file is a video file based on its extension


### PR DESCRIPTION
## Summary
- Adds support for commonly used image/video formats that Google Takeout may export
- Without these, files in unsupported formats are silently skipped during processing

### New image formats
- `.webp`, `.gif`, `.tiff`/`.tif`, `.bmp`
- RAW: `.cr2` (Canon), `.nef` (Nikon), `.arw` (Sony), `.dng` (Adobe DNG), `.rw2` (Panasonic)

### New video formats
- `.webm`, `.m4v`, `.3gp`

## Test plan
- [ ] Place a `.webp` and `.dng` file with JSON sidecars in a takeout directory and verify they are processed
- [ ] Verify existing formats (jpg, png, mp4, etc.) still work as before
- [ ] Confirm new formats appear in file count output

// ticktockbent