### PR TITLE
Strip localized prefix from year folder output names

### DIFF
--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -167,36 +167,35 @@ func IsNameExtension(extension string, path string) bool {
 	return strings.EqualFold(filepath.Ext(path), extension)
 }
 
+// Year folder prefixes of some countries
+// yearPrefixes is mostly made by AI. I have not verified these, but i assume they are primarily correct.
+// Please create an issue if you find any mistakes or if you want to add more languages.
+var yearPrefixes = []string{
+	"Photos from ",     // English
+	"Fotos von ",       // German
+	"Photos de ",       // French
+	"Foto del ",        // Italian
+	"Fotos de ",        // Spanish / Portuguese
+	"Foto's van ",      // Dutch
+	"Zdjęcia z ",       // Polish
+	"Фотографии из ",   // Russian
+	"Foton från ",      // Swedish
+	"Bilder fra ",      // Norwegian
+	"Billeder fra ",    // Danish
+	"Fotoğraflar ",     // Turkish
+	"Fotografie z ",    // Czech
+	"Fotók a ",         // Hungarian
+	"Φωτογραφίες από ", // Greek
+	"Fotografii din ",  // Romanian
+	"Foto dari ",       // Indonesian
+	"รูปภาพจาก ",       // Thai
+	"Ảnh từ ",          // Vietnamese
+}
+
 // Checks whether a directory is a standart google year folder
 func IsYearFolder(dirPath string) (bool, error) {
-	// Year folder prefixes of some countries
-	// yearPrefixes is mostly made by AI. I have not verified these, but i assume they are primarily correct.
-	// Please create an issue if you find any mistakes or if you want to add more languages.
-	yearPrefixes := []string{
-		"Photos from ",     // English
-		"Fotos von ",       // German
-		"Photos de ",       // French
-		"Foto del ",        // Italian
-		"Fotos de ",        // Spanish / Portuguese
-		"Foto's van ",      // Dutch
-		"Zdjęcia z ",       // Polish
-		"Фотографии из ",   // Russian
-		"Foton från ",      // Swedish
-		"Bilder fra ",      // Norwegian
-		"Billeder fra ",    // Danish
-		"Fotoğraflar ",     // Turkish
-		"Fotografie z ",    // Czech
-		"Fotók a ",         // Hungarian
-		"Φωτογραφίες από ", // Greek
-		"Fotografii din ",  // Romanian
-		"Foto dari ",       // Indonesian
-		"รูปภาพจาก ",       // Thai
-		"Ảnh từ ",          // Vietnamese
-	}
-
 	for _, prefix := range yearPrefixes {
 		if strings.HasPrefix(dirPath, prefix) {
-			// The rest of the string has to be 4 characters long
 			yearPart := strings.TrimPrefix(dirPath, prefix)
 			if matched, _ := regexp.MatchString(`^\d{4}$`, yearPart); matched {
 				return true, nil
@@ -204,6 +203,19 @@ func IsYearFolder(dirPath string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// Extracts the year string from a year folder name by stripping the localized prefix
+func ExtractYearFromFolder(dirName string) string {
+	for _, prefix := range yearPrefixes {
+		if strings.HasPrefix(dirName, prefix) {
+			yearPart := strings.TrimPrefix(dirName, prefix)
+			if matched, _ := regexp.MatchString(`^\d{4}$`, yearPart); matched {
+				return yearPart
+			}
+		}
+	}
+	return dirName
 }
 
 // Checks whether a file, that is provided using its path, is a media file

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -142,7 +142,6 @@ func Process(
 			}
 
 			dirPath := filepath.Join(sourcePath, dir.Name())
-			var targetPath string = filepath.Join(outputPath, dir.Name())
 
 			isYearFolder, err := IsYearFolder(dir.Name())
 			if err != nil {
@@ -152,6 +151,12 @@ func Process(
 				Log(LoggerInfo, "Skipping album folder: %s", dir.Name())
 				continue
 			}
+
+			outputDirName := dir.Name()
+			if isYearFolder {
+				outputDirName = ExtractYearFromFolder(dir.Name())
+			}
+			targetPath := filepath.Join(outputPath, outputDirName)
 
 			p = ProcessDirectory(fixerCtx, dirPath, targetPath, isYearFolder, p)
 		}


### PR DESCRIPTION
## Summary
- Extracts `yearPrefixes` to a package-level variable for reuse
- Adds `ExtractYearFromFolder` helper to strip prefixes like "Photos from "
- Output year folders are now named `1999` instead of `Photos from 1999` (and equivalents in other languages)

## Test plan
- [ ] Run with a source containing "Photos from YYYY" folders, verify output uses just "YYYY"
- [ ] Verify non-year folders (album names) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)