### PR TITLE
Deduplicate output filenames instead of silently skipping

### DIFF
--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -102,6 +102,23 @@ func IsVideoFile(path string) bool {
 	return ok
 }
 
+func deduplicatePath(path string) string {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return path
+	}
+
+	dir := filepath.Dir(path)
+	ext := filepath.Ext(path)
+	base := strings.TrimSuffix(filepath.Base(path), ext)
+
+	for i := 1; ; i++ {
+		candidate := filepath.Join(dir, fmt.Sprintf("%s-%d%s", base, i, ext))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}
+
 // Duplicate a file from one path to another
 func DuplicateFile(inputPath string, outputPath string) error {
 	sourceFile, err := os.Open(inputPath)

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -322,12 +322,7 @@ func ProcessFile(
 		return err
 	}
 
-	destPath := filepath.Join(outputDir, fileName)
-
-	if _, err := os.Stat(destPath); err == nil {
-		Log(LoggerInfo, "File %s already exists, skipping", destPath)
-		return nil
-	}
+	destPath := deduplicatePath(filepath.Join(outputDir, fileName))
 
 	// Metadata sidecar file not found, copy the file without metadata
 	if sidecarPath == "" {


### PR DESCRIPTION
## Summary
- When a file with the same name already exists in the output directory, append `-1`, `-2`, etc. before the extension instead of silently skipping the file
- Prevents data loss when re-running or when files from different source folders share a name

## Test plan
- [ ] Process files where output already contains a file with the same name
- [ ] Verify the new file gets a `-1` suffix (e.g. `IMG_001-1.jpg`)
- [ ] Verify subsequent duplicates increment (`-2`, `-3`, etc.)
- [ ] Verify first-time processing (no existing files) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)