### PR TITLE
Support multiple takeout exports as input directory

### DIFF
--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -244,6 +244,61 @@ func FindImagePartner(videoPath string) (string, error) {
 	return "", nil
 }
 
+// FindSourceRoots returns directories that contain the expected Google Photos
+// folder structure (subdirectories with media files). If the given path already
+// has that structure, it returns just that path. Otherwise it looks one level
+// deeper to support pointing at a directory of multiple takeout exports.
+func FindSourceRoots(path string) ([]string, error) {
+	if dirHasMediaSubdirs(path) {
+		return []string{path}, nil
+	}
+
+	subdirs, err := DiscoverDirs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var roots []string
+	for _, sub := range subdirs {
+		child := filepath.Join(path, sub.Name())
+		if dirHasMediaSubdirs(child) {
+			roots = append(roots, child)
+		} else {
+			grandchildren, _ := DiscoverDirs(child)
+			for _, gc := range grandchildren {
+				gcPath := filepath.Join(child, gc.Name())
+				if dirHasMediaSubdirs(gcPath) {
+					roots = append(roots, gcPath)
+				}
+			}
+		}
+	}
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no media files found in folder structure")
+	}
+	return roots, nil
+}
+
+func dirHasMediaSubdirs(path string) bool {
+	subdirs, err := DiscoverDirs(path)
+	if err != nil {
+		return false
+	}
+	for _, sub := range subdirs {
+		files, err := os.ReadDir(filepath.Join(path, sub.Name()))
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if !f.IsDir() && IsMediaFile(f.Name()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Counts all processable files in the source path
 func CountProcessableFiles(sourcePath string) (int, error) {
 	fileInfo, err := os.Stat(sourcePath)
@@ -255,17 +310,23 @@ func CountProcessableFiles(sourcePath string) (int, error) {
 		return 0, fmt.Errorf("source path is not a directory")
 	}
 
-	count := 0
-	subdirs, err := DiscoverDirs(sourcePath)
+	roots, err := FindSourceRoots(sourcePath)
 	if err != nil {
 		return 0, err
 	}
 
-	for _, dir := range subdirs {
-		files, _ := os.ReadDir(filepath.Join(sourcePath, dir.Name()))
-		for _, file := range files {
-			if !file.IsDir() && IsMediaFile(file.Name()) {
-				count++
+	count := 0
+	for _, root := range roots {
+		subdirs, err := DiscoverDirs(root)
+		if err != nil {
+			continue
+		}
+		for _, dir := range subdirs {
+			files, _ := os.ReadDir(filepath.Join(root, dir.Name()))
+			for _, file := range files {
+				if !file.IsDir() && IsMediaFile(file.Name()) {
+					count++
+				}
 			}
 		}
 	}

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -131,29 +131,41 @@ func Process(
 	// process all directories in the source directory, ignore files in the source directory itself
 	// because all media files should be inside of sub-folders
 	if fileInfo.IsDir() {
-		dirs, err := DiscoverDirs(sourcePath)
+		roots, err := FindSourceRoots(sourcePath)
 		if err != nil {
-			Log(LoggerError, "Error discovering directories: %v", err)
+			Log(LoggerError, "Error finding source roots: %v", err)
+			return err
 		}
 
-		for _, dir := range dirs {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
+		for _, root := range roots {
+			fixerCtx.SourceRoot = root
+			Log(LoggerInfo, "Processing source root: %s", root)
 
-			dirPath := filepath.Join(sourcePath, dir.Name())
-			var targetPath string = filepath.Join(outputPath, dir.Name())
-
-			isYearFolder, err := IsYearFolder(dir.Name())
+			dirs, err := DiscoverDirs(root)
 			if err != nil {
-				Log(LoggerWarn, "Failed to determine if folder is a year folder for %s: %v", dir.Name(), err)
-			}
-			if (options.IgnoreAlbums || options.Flatten) && !isYearFolder {
-				Log(LoggerInfo, "Skipping album folder: %s", dir.Name())
+				Log(LoggerError, "Error discovering directories in %s: %v", root, err)
 				continue
 			}
 
-			p = ProcessDirectory(fixerCtx, dirPath, targetPath, isYearFolder, p)
+			for _, dir := range dirs {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
+				dirPath := filepath.Join(root, dir.Name())
+				var targetPath string = filepath.Join(outputPath, dir.Name())
+
+				isYearFolder, err := IsYearFolder(dir.Name())
+				if err != nil {
+					Log(LoggerWarn, "Failed to determine if folder is a year folder for %s: %v", dir.Name(), err)
+				}
+				if (options.IgnoreAlbums || options.Flatten) && !isYearFolder {
+					Log(LoggerInfo, "Skipping album folder: %s", dir.Name())
+					continue
+				}
+
+				p = ProcessDirectory(fixerCtx, dirPath, targetPath, isYearFolder, p)
+			}
 		}
 	} else {
 		err = ProcessFile(fixerCtx, sourcePath, "", false)


### PR DESCRIPTION
## Summary
- Added `FindSourceRoots` to auto-discover Google Photos directories when the input contains multiple takeout exports
- Looks up to two levels deep for directories with the expected folder structure (subdirectories containing media files)
- If the input directory already has the expected structure, behaves exactly as before
- Updated `CountProcessableFiles` to count across all discovered source roots

Example: pointing at a directory containing `takeout-001/Google Photos/` and `takeout-002/Google Photos/` now processes both.

## Test plan
- [ ] Process a single Google Photos directory (existing behavior unchanged)
- [ ] Process a parent directory containing multiple takeout exports
- [ ] Verify file count and progress reporting are correct across multiple roots

🤖 Generated with [Claude Code](https://claude.com/claude-code)