### PR TITLE
Fix cancel to stop processing promptly

### DIFF
--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -177,26 +177,25 @@ func ProcessDirectory(
 	isYearFolder bool,
 	p Progress,
 ) Progress {
+	if fixerCtx.Ctx.Err() != nil {
+		return p
+	}
+
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		Log(LoggerError, "Error reading directory: %v", err)
 		return p
 	}
 
-	// TODO: Fix potential race conditions
-	// Job pools
-	// Buffered channel to avoid blocking
-	jobs := make(chan string, len(files))
+	jobs := make(chan string, runtime.NumCPU()*2)
 	completed := make(chan string)
-	// Channel to capture errors
 	errors := make(chan error)
 
 	sourceDirName := filepath.Base(dirPath)
 
 	var wg sync.WaitGroup
-	workerCount := runtime.NumCPU() * 2 // x2 is faster for IO tasks, x more than that has no effect based on testing
+	workerCount := runtime.NumCPU() * 2
 
-	// Start worker goroutines
 	for i := 0; i < workerCount; i++ {
 		go func() {
 			for imagePath := range jobs {
@@ -215,38 +214,38 @@ func ProcessDirectory(
 		}()
 	}
 
-	// Send jobs directly, add work group before transmitting job
-	for _, file := range files {
-		if fixerCtx.Ctx.Err() != nil {
-			break
+	go func() {
+		for _, file := range files {
+			if fixerCtx.Ctx.Err() != nil {
+				break
+			}
+			if file.IsDir() {
+				continue
+			}
+
+			imagePath := filepath.Join(dirPath, file.Name())
+
+			if !IsMediaFile(imagePath) {
+				continue
+			}
+
+			wg.Add(1)
+			select {
+			case jobs <- imagePath:
+			case <-fixerCtx.Ctx.Done():
+				wg.Done()
+			}
 		}
-		if file.IsDir() {
-			continue
-		}
+		close(jobs)
+	}()
 
-		imagePath := filepath.Join(dirPath, file.Name())
-
-		// Check whether a file is a media file
-		if !IsMediaFile(imagePath) {
-			continue
-		}
-
-		wg.Add(1)
-		jobs <- imagePath
-	}
-
-	// All jobs have been sent
-	close(jobs)
-
-	// Close completed and errors channels when all jobs are finished
 	go func() {
 		wg.Wait()
 		close(completed)
 		close(errors)
 	}()
 
-	// Update progress and handle errors
-	for {
+	for completed != nil || errors != nil {
 		select {
 		case ev, ok := <-completed:
 			if !ok {
@@ -262,12 +261,6 @@ func ProcessDirectory(
 			} else {
 				Log(LoggerError, "%v", err)
 			}
-		case <-fixerCtx.Ctx.Done():
-			// Let workers finish their current job but dont add new jobs
-		}
-
-		if completed == nil && errors == nil {
-			break
 		}
 	}
 
@@ -282,6 +275,10 @@ func ProcessFile(
 	sourceDirName string,
 	isYearFolder bool,
 ) error {
+	if fixerCtx.Ctx.Err() != nil {
+		return fixerCtx.Ctx.Err()
+	}
+
 	fileName := filepath.Base(sourcePath)
 
 	// See issue #2


### PR DESCRIPTION
## Summary
- Job buffer reduced from `len(files)` to `NumCPU*2` — only enough to keep workers fed
- Sender moved to goroutine with `select` on `ctx.Done()` so it stops immediately on cancel
- Removed `ctx.Done()` case from progress `select` — a closed channel fires every iteration, starving result reads and causing a spin loop
- Added cancel checks at `ProcessDirectory` and `ProcessFile` entry to short-circuit between directories

Previously cancel could take minutes as hundreds of pre-queued files continued processing. Now at most `NumCPU*2` in-flight files complete before stopping.

## Test plan
- [ ] Start processing a large directory, click Cancel mid-way
- [ ] Verify processing stops within a few seconds (only in-flight files finish)
- [ ] Verify Cancel button grays out and status shows "Cancelled"
- [ ] Verify normal processing (without cancel) still completes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)