### PR TITLE
Use EXIF and filename dates as fallback for sidecar-less files

### DIFF
--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -287,10 +287,6 @@ func DetectFileMonth(sourcePath string, sidecarPath string) (int, error) {
 		}
 	}
 
-	if exifDate, err := ReadExifDate(sourcePath); err == nil {
-		return int(exifDate.Month()), nil
-	}
-
 	fileInfo, err := os.Stat(sourcePath)
 	if err != nil {
 		return 0, err

--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -276,21 +276,19 @@ func CountProcessableFiles(sourcePath string) (int, error) {
 	return count, nil
 }
 
-// Detect the month of a file based on its sidecar metadata
-// Returns the month as an integer between 1 and 12
 func DetectFileMonth(sourcePath string, sidecarPath string) (int, error) {
 	if sidecarPath != "" {
 		metadata, err := ReadJsonMetadata(sidecarPath)
-		if err != nil {
-			return 0, err
+		if err == nil {
+			timestamp, err := strconv.ParseInt(metadata.PhotoTakenTime.Timestamp, 10, 64)
+			if err == nil {
+				return int(time.Unix(timestamp, 0).Month()), nil
+			}
 		}
+	}
 
-		timestamp, err := strconv.ParseInt(metadata.PhotoTakenTime.Timestamp, 10, 64)
-		if err != nil {
-			return 0, err
-		}
-
-		return int(time.Unix(timestamp, 0).Month()), nil
+	if exifDate, err := ReadExifDate(sourcePath); err == nil {
+		return int(exifDate.Month()), nil
 	}
 
 	fileInfo, err := os.Stat(sourcePath)
@@ -299,6 +297,42 @@ func DetectFileMonth(sourcePath string, sidecarPath string) (int, error) {
 	}
 
 	return int(fileInfo.ModTime().Month()), nil
+}
+
+const dateSep = `[-:._]?`
+const dateTimeSep = `[-:._ ]?`
+
+var dateTimeRe = regexp.MustCompile(
+	`(?:^|[^0-9])` +
+		`(\d{4})` + dateSep + `(\d{2})` + dateSep + `(\d{2})` +
+		`(?:` + dateTimeSep + `(\d{2})` + dateSep + `(\d{2})` + dateSep + `(\d{2}))?`,
+)
+
+func parseDateFromFileName(fileName string) (time.Time, bool) {
+	name := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+
+	m := dateTimeRe.FindStringSubmatch(name)
+	if m == nil {
+		return time.Time{}, false
+	}
+
+	year, _ := strconv.Atoi(m[1])
+	month, _ := strconv.Atoi(m[2])
+	day, _ := strconv.Atoi(m[3])
+
+	if year < 1970 || year > 2100 || month < 1 || month > 12 || day < 1 || day > 31 {
+		return time.Time{}, false
+	}
+
+	hour, min, sec := 0, 0, 0
+	if m[4] != "" {
+		hour, _ = strconv.Atoi(m[4])
+		min, _ = strconv.Atoi(m[5])
+		sec, _ = strconv.Atoi(m[6])
+	}
+
+	t := time.Date(year, time.Month(month), day, hour, min, sec, 0, time.UTC)
+	return t, true
 }
 
 func ResolveOutputDir(

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -427,7 +427,19 @@ func CreateFixedFile(
 			}
 		}
 	} else if fixerCtx.Options.WriteMetadata && fileMetadataPath == "" {
-		Log(LoggerInfo, "WriteMetadata enabled but no sidecar for %s — skipping metadata write", fileName)
+		Log(LoggerInfo, "WriteMetadata enabled but no sidecar for %s — attempting EXIF/filename date", fileName)
+
+		if exifDate, err := ReadExifDate(filePath); err == nil {
+			Log(LoggerInfo, "Found EXIF date for %s: %s", fileName, exifDate.Format("2006-01-02 15:04:05"))
+			if err := SetFileBirthTime(destPath, exifDate); err != nil {
+				Log(LoggerWarn, "Failed to set birth time from EXIF for %s: %v", fileName, err)
+			}
+		} else if fileDate, ok := parseDateFromFileName(filepath.Base(filePath)); ok {
+			Log(LoggerInfo, "Using filename date for %s: %s", fileName, fileDate.Format("2006-01-02 15:04:05"))
+			if err := SetFileBirthTime(destPath, fileDate); err != nil {
+				Log(LoggerWarn, "Failed to set birth time from filename for %s: %v", fileName, err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/fixer/metadata_handler.go
+++ b/internal/fixer/metadata_handler.go
@@ -235,6 +235,63 @@ func ApplyMetadata(filePath string, meta imageMetadata) error {
 	return nil
 }
 
+// ReadExifDate reads DateTimeOriginal from a file's existing EXIF data
+func ReadExifDate(filePath string) (time.Time, error) {
+	exifToolMutex.Lock()
+	defer exifToolMutex.Unlock()
+
+	if exifToolCmd == nil {
+		return time.Time{}, fmt.Errorf("exiftool not initialized")
+	}
+
+	if _, err := fmt.Fprintf(exifToolStdin, "-DateTimeOriginal\n-CreateDate\n-s3\n-charset\nfilename=utf8\n%s\n-execute\n", filePath); err != nil {
+		return time.Time{}, err
+	}
+
+	var dateStr string
+	for exifToolScanner.Scan() {
+		line := exifToolScanner.Text()
+		if line == "{ready}" {
+			break
+		}
+		if dateStr == "" && !strings.Contains(line, "Error") && strings.TrimSpace(line) != "" {
+			dateStr = strings.TrimSpace(line)
+		}
+	}
+
+	if err := exifToolScanner.Err(); err != nil {
+		return time.Time{}, err
+	}
+
+	if dateStr == "" {
+		return time.Time{}, fmt.Errorf("no EXIF date found")
+	}
+
+	for _, layout := range []string{
+		"2006:01:02 15:04:05",
+		"2006:01:02 15:04:05-07:00",
+		"2006:01:02 15:04:05+07:00",
+	} {
+		if t, err := time.Parse(layout, dateStr); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("could not parse EXIF date: %s", dateStr)
+}
+
+func SetFileBirthTime(filePath string, t time.Time) error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	setfileFormat := t.Format("01/02/2006 15:04:05")
+	cmd := exec.Command("SetFile", "-d", setfileFormat, filePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("SetFile failed: %v, output: %s", err, string(output))
+	}
+	return nil
+}
+
 // GetMajorBrand reads the MajorBrand tag from a file using the persistent exiftool instance
 func GetMajorBrand(filePath string) (string, error) {
 	exifToolMutex.Lock()


### PR DESCRIPTION
## Summary
- Added `ReadExifDate` to read DateTimeOriginal/CreateDate from a file's existing EXIF data via the persistent exiftool instance
- Files without sidecar JSON now get their birth time set from EXIF data or filename date
- `DetectFileMonth` also uses EXIF as a fallback for month subfolder placement
- Flexible filename date parsing supports YYYYMMDD, YYYY-MM-DD, YYYY.MM.DD with optional time

Fallback chain: sidecar JSON → EXIF data → filename date

## Test plan
- [ ] Process files that have EXIF dates but no sidecar JSON
- [ ] Verify their Created date in Finder shows the EXIF date, not today
- [ ] Process files with date-encoded filenames but no sidecar or EXIF
- [ ] Verify their Created date matches the filename date
- [ ] Verify files with sidecars still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)