### PR TITLE
feat: OneDrive cloud-sync support, extended media formats, and automated migration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 logs/
 scripts/*.log
 scripts/migration-progress.json
+*.exe
+main.exe
+.claude/
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 .directory
 logs/
+scripts/*.log
+scripts/migration-progress.json

--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ You might have to give the executable permissions to run on Linux and macOS usin
 - A simple website for users who are not familiar with Github
 - Pull request and issue template
 
+## Building from source
+
+Requires [Go](https://go.dev/) and a C compiler ([GCC via scoop](https://scoop.sh/) on Windows: `scoop install mingw`). The GUI uses [Fyne](https://fyne.io/) which requires CGO.
+
+**Windows** — use the provided build script:
+```powershell
+# Build both GUI and CLI binaries
+.\scripts\build-windows.ps1
+
+# Build only the CLI binary (for scripting/automation)
+.\scripts\build-windows.ps1 -Target cli
+```
+
+**Linux / macOS:**
+```sh
+# GUI binary
+CGO_ENABLED=1 go build -ldflags "-s -w" -o GoogleTakeoutFixer ./cmd/main.go
+
+# CLI binary
+CGO_ENABLED=1 go build -ldflags "-s -w" -o GoogleTakeoutFixerCLI ./cmd/main.go
+```
+
 ## Credits
 This project modifies metadata using the [ExifTool](https://exiftool.org/) library by **Phil Harvey**. ExifTool is licensed under the Perl Artistic license, or the GNU General Public License (see [here](https://exiftool.org/#license) for more details).
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,26 @@ You can also use GoogleTakeoutFixer through the CLI. Use the following flags:
 - `--ignore-albums`: Ignore album folders and only process year folders
 - `--month-subfolders`: Create month subfolders (labeled 1-12) inside of folders
 - `--flatten`: Flatten the folder structure and put all files directly in the output folder
-- `--restore-mov`: Restore .MOV file extension in case the Major Brand EXIF field says \"Apple QuickTime (.MOV/QT)\" (See #2)
+- `--restore-mov`: Restore .MOV file extension in case the Major Brand EXIF field says "Apple QuickTime (.MOV/QT)" (See #2)
 - `--version`: Show version
 - `--help`: Show help message
 
 Example usage:
 ```sh
 ./GoogleTakeoutFixer --input "/path/to/takeout/Google Photos/" --output "/path/to/output/folder/" --symlink
-``` 
+```
+
+#### Diagnostic scan mode
+
+Before running a full export, you can audit your Takeout folder to find media files that have no matching `.json` sidecar (and would therefore be copied without metadata):
+
+```sh
+./GoogleTakeoutFixer --scan "/path/to/takeout/Google Photos/"
+```
+
+Additional scan flags:
+- `--scan-limit N`: Only inspect the first N unmatched media files (useful for a quick spot-check)
+- `--scan-verbose`: Show byte-level filename debug info for each unmatched file
 
 You might have to give the executable permissions to run on Linux and macOS using `chmod +x GoogleTakeoutFixer` before you can run it through the terminal.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -40,6 +40,9 @@ func Main() {
 	showVersion := flag.Bool("version", false, "Show current version")
 	inputPath := flag.String("input", "", "Path to Google takeout directory")
 	outputPath := flag.String("output", "", "Path to output directory")
+	scanPath := flag.String("scan", "", "Scan a takeout folder and report media files without matching .json sidecars")
+	scanLimit := flag.Int("scan-limit", 0, "Limit how many media files to scan (0 = unlimited)")
+	scanVerbose := flag.Bool("scan-verbose", false, "Show byte-level debug info for unmatched files")
 	useSymlinks := flag.Bool("symlink", false, "Use symlinks inside of albums instead of duplicating images")
 	skipMetadata := flag.Bool("skip-metadata", false, "Skip writing metadata to files")
 	ignoreAlbums := flag.Bool("ignore-albums", false, "Ignore all album folders")
@@ -51,6 +54,11 @@ func Main() {
 
 	if *showVersion {
 		fmt.Println(version.Tag)
+		return
+	}
+
+	if *scanPath != "" {
+		runScan(*scanPath, *scanLimit, *scanVerbose)
 		return
 	}
 
@@ -88,9 +96,10 @@ func Main() {
 		RestoreMOVExtension: *restoreMOV,
 	}
 
+	var processErr error
 	go func() {
-		// Invert skipMetadata because the flag is named skipMetadata but the process function expects writeMetadata
 		if err := fixer.Process(context.Background(), *inputPath, *outputPath, progressCh, options); err != nil {
+			processErr = err
 			fmt.Printf("Error during processing: %v\n", err)
 		}
 	}()
@@ -110,5 +119,26 @@ func Main() {
 		)
 	}
 
-	fmt.Println("\nDone")
+	errs, warns := fixer.LogCounts()
+	if errs > 0 || processErr != nil {
+		fmt.Printf("\nDone — %d error(s), %d warning(s). Check log for details: %s\n", errs, warns, fixer.CurrentLogFilePath())
+		os.Exit(1)
+	}
+	fmt.Printf("\nDone — %d error(s), %d warning(s)\n", errs, warns)
+}
+
+func runScan(scanPath string, limit int, verbose bool) {
+	fmt.Printf("Scanning: %s\n", scanPath)
+	if limit > 0 {
+		fmt.Printf("Limit: first %d media files\n", limit)
+	}
+	fmt.Println()
+
+	result, err := fixer.Scan(scanPath, limit, verbose)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(fixer.FormatScanResult(result))
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -124,6 +124,10 @@ func Main() {
 		fmt.Printf("\nDone — %d error(s), %d warning(s). Check log for details: %s\n", errs, warns, fixer.CurrentLogFilePath())
 		os.Exit(1)
 	}
+	if warns > 0 {
+		fmt.Printf("\nDone — %d error(s), %d warning(s). Check log for details: %s\n", errs, warns, fixer.CurrentLogFilePath())
+		os.Exit(2)
+	}
 	fmt.Printf("\nDone — %d error(s), %d warning(s)\n", errs, warns)
 }
 

--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -547,9 +547,6 @@ func CountProcessableFiles(sourcePath string) (int, error) {
 		}
 	}
 
-	if count == 0 {
-		return 0, fmt.Errorf("no media files found in folder structure")
-	}
 	return count, nil
 }
 

--- a/internal/fixer/file_handler.go
+++ b/internal/fixer/file_handler.go
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 package fixer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -86,6 +87,14 @@ var imageExtensions = map[string]struct{}{
 	".jpeg": {},
 	".png":  {},
 	".heic": {},
+	".heif": {}, // HEIF container — same format as HEIC, different extension
+	".gif":  {},
+	".nef":  {}, // Nikon RAW
+	".dng":  {}, // Adobe Digital Negative RAW (common in Android exports)
+	".webp": {}, // WebP (used by modern Android/Chrome)
+	".bmp":  {},
+	".tiff": {},
+	".tif":  {},
 }
 
 var videoExtensions = map[string]struct{}{
@@ -93,6 +102,10 @@ var videoExtensions = map[string]struct{}{
 	".mov": {},
 	".avi": {},
 	".mkv": {},
+	".3gp": {}, // 3GPP — old Android video format
+	".m4v": {}, // Apple video container (essentially MP4)
+	".wmv": {},
+	".flv": {},
 }
 
 // Checks whether a file is a video file based on its extension
@@ -139,23 +152,223 @@ func DiscoverDirs(path string) ([]os.DirEntry, error) {
 	return dirList, nil
 }
 
+const supplementalSuffix = ".supplemental-metadata"
+
+// isSupplementalMatch checks if a lowercased json filename matches the pattern
+// "imageNameLower + <truncated .supplemental-metadata> + .json".
+// Uses prefix+suffix matching instead of exact byte-length computation to handle
+// double-encoded UTF-8 filenames (e.g. from OneDrive sync).
+func isSupplementalMatch(jsonLower string, imageNameLower string) bool {
+	if !strings.HasSuffix(jsonLower, ".json") {
+		return false
+	}
+	jsonBase := strings.TrimSuffix(jsonLower, ".json")
+	if !strings.HasPrefix(jsonBase, imageNameLower) {
+		return false
+	}
+	remainder := jsonBase[len(imageNameLower):]
+	// remainder should be a prefix of ".supplemental-metadata" (possibly truncated)
+	return len(remainder) > 0 && strings.HasPrefix(supplementalSuffix, remainder)
+}
+
 // Find a matching sidecar JSON
 func FindSidecar(imagePath string) (string, error) {
-	// Scan directory non case sensitively for JSON sidecar files
 	dir := filepath.Dir(imagePath)
-	base := strings.TrimSuffix(filepath.Base(imagePath), filepath.Ext(imagePath))
+	imageName := filepath.Base(imagePath)
+	base := strings.TrimSuffix(imageName, filepath.Ext(imageName))
 	prefix := strings.ToLower(base)
+	ext := strings.ToLower(filepath.Ext(imageName))
 
 	entries, err := ReadDirCached(dir)
 	if err != nil {
 		return "", err
 	}
 
+	imageNameLower := strings.ToLower(imageName)
+
+	// 1. Try exact matches first
 	for _, entry := range entries {
 		name := entry.Name()
 		lower := strings.ToLower(name)
-		if strings.HasPrefix(lower, prefix) && strings.HasSuffix(lower, ".json") {
+		if !strings.HasSuffix(lower, ".json") {
+			continue
+		}
+
+		// Standard: image.jpg.json
+		if lower == imageNameLower+".json" {
 			return filepath.Join(dir, name), nil
+		}
+
+		// Alternative: image.json
+		if strings.TrimSuffix(lower, ".json") == prefix {
+			return filepath.Join(dir, name), nil
+		}
+
+		// Supplemental metadata: Google Takeout creates sidecars like
+		// "image.jpg.supplemental-metadata.json", truncated to ~51 chars.
+		// Instead of computing exact byte length (which breaks with double-encoded UTF-8),
+		// use prefix+suffix matching: json starts with imageName and the middle part
+		// is a prefix of ".supplemental-metadata".
+		// Two variants: "image.jpg.supplemental-metadata.json" and "image.supplemental-metadata.json"
+		if isSupplementalMatch(lower, imageNameLower) || isSupplementalMatch(lower, prefix) {
+			return filepath.Join(dir, name), nil
+		}
+	}
+
+	// 2. Fallback for Google Photos duplicates (e.g. "image(1).jpg" -> "image.jpg.supplemental-metadata(1).json")
+	duplicateRegex := regexp.MustCompile(`^(.*)\((\d+)\)$`)
+	if match := duplicateRegex.FindStringSubmatch(prefix); match != nil {
+		realBase := match[1]
+		num := match[2]
+
+		expectedJson1 := fmt.Sprintf("%s%s.supplemental-metadata(%s).json", realBase, ext, num)
+		expectedJson2 := fmt.Sprintf("%s%s(%s).json", realBase, ext, num)
+		expectedJson3 := fmt.Sprintf("%s(%s).json", realBase, num)
+		expectedJson4 := fmt.Sprintf("%s.supplemental-metadata(%s).json", realBase, num)
+
+		// Also build the original image name (without duplicate number) for matching
+		realImageName := realBase + ext
+		numSuffix := fmt.Sprintf("(%s)", num)
+
+		for _, entry := range entries {
+			name := entry.Name()
+			lower := strings.ToLower(name)
+			if lower == expectedJson1 || lower == expectedJson2 || lower == expectedJson3 || lower == expectedJson4 {
+				return filepath.Join(dir, name), nil
+			}
+			// Truncated supplemental for the duplicate filename itself
+			// e.g. "image(2).jpg" -> "image(2).jpg..json"
+			if isSupplementalMatch(lower, imageNameLower) {
+				return filepath.Join(dir, name), nil
+			}
+			// Truncated supplemental with (N) after the truncated suffix
+			// e.g. "image(1).jpg" -> "image.jpg.supplemental-metad(1).json"
+			if strings.HasSuffix(lower, ".json") {
+				jsonBase := strings.TrimSuffix(lower, ".json")
+				for _, baseVariant := range []string{realImageName, realBase} {
+					prefix := baseVariant + "."
+					if strings.HasPrefix(jsonBase, prefix) && strings.HasSuffix(jsonBase, numSuffix) {
+						middle := jsonBase[len(baseVariant) : len(jsonBase)-len(numSuffix)]
+						if strings.HasPrefix(supplementalSuffix, middle) {
+							return filepath.Join(dir, name), nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 3. Fallback for truncated filenames (Google Takeout truncates sidecar names to 51 chars)
+	// Two truncation modes:
+	//   a) The image base name (without ext) is truncated in the JSON filename
+	//   b) The full image name (with ext) is truncated, cutting into the extension
+	//      e.g. "long name.jpg" -> sidecar "long name.j.json" (51 chars total)
+	if len(prefix) >= 40 || len(imageNameLower) > 46 {
+		for _, entry := range entries {
+			name := entry.Name()
+			lower := strings.ToLower(name)
+			if !strings.HasSuffix(lower, ".json") {
+				continue
+			}
+			jsonBase := strings.TrimSuffix(lower, ".json")
+			if len(jsonBase) < 40 {
+				continue
+			}
+			// (a) JSON base is a truncated version of the image base (without ext)
+			if strings.HasPrefix(prefix, jsonBase) {
+				return filepath.Join(dir, name), nil
+			}
+			// (b) JSON base is a truncated version of the full image name (with ext)
+			if strings.HasPrefix(imageNameLower, jsonBase) {
+				return filepath.Join(dir, name), nil
+			}
+		}
+	}
+
+	// 4. Fallback for Google Photos "-edited" files (including "-edited(N)" combos)
+	// e.g. "IMG-edited.jpg" -> "IMG.jpg.json" or "IMG.supplemental-metadata.json"
+	// e.g. "IMG-edited(1).jpg" -> "IMG.jpg.supplemental-metadata(1).json"
+	editedRegex := regexp.MustCompile(`^(.*)-edited(?:\((\d+)\))?$`)
+	if editedMatch := editedRegex.FindStringSubmatch(prefix); editedMatch != nil {
+		prefixOriginal := editedMatch[1]
+		editedNum := editedMatch[2] // may be empty
+		originalImageName := prefixOriginal + ext
+
+		for _, entry := range entries {
+			name := entry.Name()
+			lower := strings.ToLower(name)
+			if !strings.HasSuffix(lower, ".json") {
+				continue
+			}
+			jsonBase := strings.TrimSuffix(lower, ".json")
+
+			// original.json
+			if jsonBase == prefixOriginal {
+				return filepath.Join(dir, name), nil
+			}
+
+			// original.jpg.json
+			if jsonBase == originalImageName {
+				return filepath.Join(dir, name), nil
+			}
+
+			// original.jpg.supplemental-metadata.json or original.supplemental-metadata.json
+			if isSupplementalMatch(lower, originalImageName) || isSupplementalMatch(lower, prefixOriginal) {
+				return filepath.Join(dir, name), nil
+			}
+
+			// For "-edited(N)": look for "original.jpg.supplemental-metadata(N).json" patterns
+			if editedNum != "" {
+				expected1 := fmt.Sprintf("%s.supplemental-metadata(%s).json", originalImageName, editedNum)
+				expected2 := fmt.Sprintf("%s(%s).json", originalImageName, editedNum)
+				expected3 := fmt.Sprintf("%s.supplemental-metadata(%s).json", prefixOriginal, editedNum)
+				expected4 := fmt.Sprintf("%s(%s).json", prefixOriginal, editedNum)
+				if lower == expected1 || lower == expected2 || lower == expected3 || lower == expected4 {
+					return filepath.Join(dir, name), nil
+				}
+			}
+
+			// Truncated long filenames fallback
+			if len(jsonBase) >= 40 {
+				if strings.HasPrefix(prefixOriginal, jsonBase) || strings.HasPrefix(originalImageName, jsonBase) {
+					return filepath.Join(dir, name), nil
+				}
+			}
+		}
+	}
+
+	// 5. Fallback for truncated media filenames with "-edited" or "(N)-edited"
+	// e.g. "longname(2)-edite.jpg" is a truncated "longname(2)-edited.jpg"
+	// Try matching against the sidecar for "longname(2).jpg"
+	if strings.Contains(prefix, "-e") && len(prefix) >= 40 {
+		// Try stripping various truncations of "-edited" (from most complete to least)
+		for _, suffix := range []string{"-edited", "-edite", "-edit", "-edi", "-ed", "-e"} {
+			if !strings.HasSuffix(prefix, suffix) {
+				continue
+			}
+			strippedBase := strings.TrimSuffix(prefix, suffix)
+			strippedImageName := strippedBase + ext
+			for _, entry := range entries {
+				name := entry.Name()
+				lower := strings.ToLower(name)
+				if !strings.HasSuffix(lower, ".json") {
+					continue
+				}
+				jsonBase := strings.TrimSuffix(lower, ".json")
+				if jsonBase == strippedBase || jsonBase == strippedImageName {
+					return filepath.Join(dir, name), nil
+				}
+				if isSupplementalMatch(lower, strippedImageName) || isSupplementalMatch(lower, strippedBase) {
+					return filepath.Join(dir, name), nil
+				}
+				// Truncated sidecar: jsonBase is a prefix of the stripped image name
+				if len(jsonBase) >= 40 {
+					if strings.HasPrefix(strippedBase, jsonBase) || strings.HasPrefix(strippedImageName, jsonBase) {
+						return filepath.Join(dir, name), nil
+					}
+				}
+			}
+			break
 		}
 	}
 
@@ -211,7 +424,71 @@ func IsMediaFile(path string) bool {
 	extension := strings.ToLower(filepath.Ext(path))
 	_, isImage := imageExtensions[extension]
 	_, isVideo := videoExtensions[extension]
-	return isImage || isVideo
+	if isImage || isVideo {
+		return true
+	}
+	// No extension: probe the first few bytes to detect common media formats.
+	// Google Photos sometimes exports files without an extension when the
+	// original upload had none. We check magic bytes to avoid false positives.
+	if extension == "" {
+		return sniffMediaMagic(path)
+	}
+	return false
+}
+
+// detectExtensionByMagic reads up to 12 bytes from path and returns the
+// appropriate file extension (e.g. ".jpg") for known image/video formats,
+// or "" if the format is unrecognised. Used only for extensionless files.
+func detectExtensionByMagic(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	buf := make([]byte, 12)
+	n, err := f.Read(buf)
+	if err != nil || n < 4 {
+		return ""
+	}
+
+	// JPEG: FF D8 FF
+	if buf[0] == 0xFF && buf[1] == 0xD8 && buf[2] == 0xFF {
+		return ".jpg"
+	}
+	// PNG: 89 50 4E 47
+	if buf[0] == 0x89 && buf[1] == 0x50 && buf[2] == 0x4E && buf[3] == 0x47 {
+		return ".png"
+	}
+	// GIF: GIF8
+	if buf[0] == 0x47 && buf[1] == 0x49 && buf[2] == 0x46 && buf[3] == 0x38 {
+		return ".gif"
+	}
+	// WebP: RIFF????WEBP
+	if n >= 12 && buf[0] == 0x52 && buf[1] == 0x49 && buf[2] == 0x46 && buf[3] == 0x46 &&
+		buf[8] == 0x57 && buf[9] == 0x45 && buf[10] == 0x42 && buf[11] == 0x50 {
+		return ".webp"
+	}
+	// HEIC/HEIF and ISO Base Media (MP4, MOV, 3GP, M4V): ftyp box at offset 4
+	if n >= 8 && buf[4] == 0x66 && buf[5] == 0x74 && buf[6] == 0x79 && buf[7] == 0x70 {
+		// Distinguish HEIC/HEIF from video containers by the brand code at offset 8
+		if n >= 12 {
+			brand := string(buf[8:12])
+			switch brand {
+			case "heic", "heix", "hevc", "hevx", "heim", "heis", "hevm", "hevs", "mif1", "msf1":
+				return ".heic"
+			}
+		}
+		return ".mp4"
+	}
+
+	return ""
+}
+
+// sniffMediaMagic returns true when the file at path begins with the magic
+// bytes of a known image or video format. Used by IsMediaFile for extensionless files.
+func sniffMediaMagic(path string) bool {
+	return detectExtensionByMagic(path) != ""
 }
 
 // Attempts to find an image file with the same base name as the video file
@@ -277,20 +554,22 @@ func CountProcessableFiles(sourcePath string) (int, error) {
 }
 
 // Detect the month of a file based on its sidecar metadata
-// Returns the month as an integer between 1 and 12
+// Returns the month as an integer between 1 and 12.
+// If the sidecar is missing or is a cloud-sync placeholder
+// (ErrSidecarOffline), it falls back to the source file's mtime so that
+// --month-subfolders continues to work during batched OneDrive migrations.
 func DetectFileMonth(sourcePath string, sidecarPath string) (int, error) {
 	if sidecarPath != "" {
 		metadata, err := ReadJsonMetadata(sidecarPath)
-		if err != nil {
+		if err == nil {
+			timestamp, tErr := strconv.ParseInt(metadata.PhotoTakenTime.Timestamp, 10, 64)
+			if tErr == nil {
+				return int(time.Unix(timestamp, 0).Month()), nil
+			}
+		} else if !errors.Is(err, ErrSidecarOffline) {
 			return 0, err
 		}
-
-		timestamp, err := strconv.ParseInt(metadata.PhotoTakenTime.Timestamp, 10, 64)
-		if err != nil {
-			return 0, err
-		}
-
-		return int(time.Unix(timestamp, 0).Month()), nil
+		// Offline placeholder: fall through to mtime fallback below.
 	}
 
 	fileInfo, err := os.Stat(sourcePath)

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -123,6 +123,10 @@ func Process(
 		Log(LoggerError, "Error counting images: %v", err)
 		return err
 	}
+	if amountImages == 0 {
+		Log(LoggerInfo, "No media files found in folder structure — nothing to process")
+		return nil
+	}
 	p.Total = amountImages
 	progressCh <- p
 

--- a/internal/fixer/fixer.go
+++ b/internal/fixer/fixer.go
@@ -20,10 +20,12 @@ package fixer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -84,15 +86,25 @@ func Process(
 
 	Log(LoggerInfo, "Starting processing with source: %s and output: %s", sourcePath, outputPath)
 
-	// Log total processing time when processing is done
-	startTime := time.Now()
-	defer func() {
-		Log(LoggerInfo, "Total processing time: %s", time.Since(startTime).Round(time.Second))
-		ClearCache()
-	}()
-
 	defer close(progressCh)
 	p := Progress{}
+
+	// Emit a summary and timing line when processing finishes.
+	startTime := time.Now()
+	defer func() {
+		errs, warns := LogCounts()
+		elapsed := time.Since(startTime).Round(time.Second)
+		if errs > 0 {
+			Log(LoggerError, "Finished: %d processed, %d error(s), %d warning(s) — check log for details", p.Processed, errs, warns)
+		} else {
+			Log(LoggerInfo, "Finished: %d processed, %d error(s), %d warning(s)", p.Processed, errs, warns)
+		}
+		Log(LoggerInfo, "Total processing time: %s", elapsed)
+		if path := CurrentLogFilePath(); path != "" {
+			Log(LoggerInfo, "Log file: %s", path)
+		}
+		ClearCache()
+	}()
 
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -153,6 +165,7 @@ func Process(
 				continue
 			}
 
+			Log(LoggerInfo, "Processing directory: %s", dirPath)
 			p = ProcessDirectory(fixerCtx, dirPath, targetPath, isYearFolder, p)
 		}
 	} else {
@@ -200,17 +213,26 @@ func ProcessDirectory(
 	for i := 0; i < workerCount; i++ {
 		go func() {
 			for imagePath := range jobs {
-				if fixerCtx.Ctx.Err() != nil {
-					wg.Done()
-					continue
-				}
-				err := ProcessFile(fixerCtx, imagePath, sourceDirName, isYearFolder)
-				if err != nil {
-					errors <- fmt.Errorf("error processing file %s: %w", imagePath, err)
-				} else {
-					completed <- imagePath
-				}
-				wg.Done()
+				func() {
+					defer wg.Done()
+					// Recover from unexpected panics so a single corrupt file
+					// can't silently kill a worker and stall the whole run.
+					defer func() {
+						if r := recover(); r != nil {
+							errors <- fmt.Errorf("PANIC processing %s: %v\n%s", imagePath, r, debug.Stack())
+						}
+					}()
+
+					if fixerCtx.Ctx.Err() != nil {
+						return
+					}
+					err := ProcessFile(fixerCtx, imagePath, sourceDirName, isYearFolder)
+					if err != nil {
+						errors <- fmt.Errorf("error processing file %s: %w", imagePath, err)
+					} else {
+						completed <- imagePath
+					}
+				}()
 			}
 		}()
 	}
@@ -282,7 +304,27 @@ func ProcessFile(
 	sourceDirName string,
 	isYearFolder bool,
 ) error {
+	// Early skip for cloud-sync placeholders (OneDrive Files On-Demand, etc.).
+	// Copying these would produce zero-byte output files — skip and tell the
+	// user to hydrate the source folder instead. os.Stat does not trigger a
+	// download, so this check is safe and cheap.
+	if srcInfo, err := os.Stat(sourcePath); err == nil {
+		if isCloudPlaceholder(srcInfo) || srcInfo.Size() == 0 {
+			Log(LoggerWarn, "Source %s is a cloud placeholder (not downloaded locally). Hydrate the source folder (OneDrive → Always keep on this device) and retry — skipping.", sourcePath)
+			return nil
+		}
+	}
+
 	fileName := filepath.Base(sourcePath)
+
+	// Extensionless files: detect the actual format via magic bytes and
+	// append the correct extension so the output file is recognisable.
+	if filepath.Ext(fileName) == "" {
+		if ext := detectExtensionByMagic(sourcePath); ext != "" {
+			Log(LoggerInfo, "Extensionless file %s detected as %s — renaming output to %s%s", fileName, ext, fileName, ext)
+			fileName = fileName + ext
+		}
+	}
 
 	// See issue #2
 	if fixerCtx.Options.RestoreMOVExtension && strings.EqualFold(filepath.Ext(fileName), ".mp4") {
@@ -418,7 +460,11 @@ func CreateFixedFile(
 	if fixerCtx.Options.WriteMetadata && fileMetadataPath != "" {
 		metadata, err := ReadJsonMetadata(fileMetadataPath)
 		if err != nil {
-			Log(LoggerError, "Failed to read metadata from %s: %v", fileMetadataPath, err)
+			if errors.Is(err, ErrSidecarOffline) {
+				Log(LoggerWarn, "Sidecar %s is a cloud placeholder (not downloaded locally). Hydrate the source folder and retry — copied without metadata.", fileMetadataPath)
+			} else {
+				Log(LoggerError, "Failed to read metadata from %s: %v", fileMetadataPath, err)
+			}
 		} else {
 			// Only apply metadata if reading was successful
 			err = ApplyMetadata(destPath, metadata)

--- a/internal/fixer/logger.go
+++ b/internal/fixer/logger.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -38,9 +39,18 @@ const (
 var LogHandler func(level LogLevel, message string)
 
 var (
-	logFileMu sync.Mutex
-	logFile   *os.File
+	logFileMu    sync.Mutex
+	logFile      *os.File
+	logFilePath  string
+	logErrCount  int64
+	logWarnCount int64
 )
+
+// LogDir controls where log files are written. When empty (the default),
+// InitializeFileLogger resolves the directory relative to the running
+// executable so logs land in a predictable place regardless of the
+// working directory at invocation time.
+var LogDir string
 
 func InitializeFileLogger() error {
 	logFileMu.Lock()
@@ -51,12 +61,27 @@ func InitializeFileLogger() error {
 		logFile = nil
 	}
 
-	if err := os.MkdirAll("logs", 0o755); err != nil {
+	// Reset per-run counters.
+	atomic.StoreInt64(&logErrCount, 0)
+	atomic.StoreInt64(&logWarnCount, 0)
+
+	// Resolve log directory: explicit override → exe dir → cwd fallback.
+	dir := LogDir
+	if dir == "" {
+		if exePath, err := os.Executable(); err == nil {
+			dir = filepath.Join(filepath.Dir(exePath), "logs")
+		}
+	}
+	if dir == "" {
+		dir = "logs"
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
 	fileName := fmt.Sprintf("%s.txt", time.Now().Format("2006-01-02_15-04-05"))
-	filePath := filepath.Join("logs", fileName)
+	filePath := filepath.Join(dir, fileName)
 
 	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
@@ -64,7 +89,16 @@ func InitializeFileLogger() error {
 	}
 
 	logFile = file
+	logFilePath = filePath
 	return nil
+}
+
+// CurrentLogFilePath returns the path of the active log file, or "" if
+// file logging has not been initialised.
+func CurrentLogFilePath() string {
+	logFileMu.Lock()
+	defer logFileMu.Unlock()
+	return logFilePath
 }
 
 func CloseFileLogger() error {
@@ -80,8 +114,17 @@ func CloseFileLogger() error {
 	return err
 }
 
-// Send a log message to the handler
+// Log sends a log message to the file and the registered LogHandler.
+// Error and warning counts are tracked atomically so a summary can be
+// emitted at the end of a processing run.
 func Log(level LogLevel, format string, args ...interface{}) {
+	switch level {
+	case LoggerError:
+		atomic.AddInt64(&logErrCount, 1)
+	case LoggerWarn:
+		atomic.AddInt64(&logWarnCount, 1)
+	}
+
 	msg := fmt.Sprintf(format, args...)
 	timestamp := time.Now().Format(time.RFC3339)
 	logLine := fmt.Sprintf("[%s] [%s] %s\n", timestamp, level, msg)
@@ -95,4 +138,10 @@ func Log(level LogLevel, format string, args ...interface{}) {
 	if LogHandler != nil {
 		LogHandler(level, msg)
 	}
+}
+
+// LogCounts returns the number of error and warning messages logged
+// since the last call to InitializeFileLogger.
+func LogCounts() (errors, warnings int64) {
+	return atomic.LoadInt64(&logErrCount), atomic.LoadInt64(&logWarnCount)
 }

--- a/internal/fixer/metadata_handler.go
+++ b/internal/fixer/metadata_handler.go
@@ -21,6 +21,7 @@ package fixer
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -37,6 +38,13 @@ import (
 	"github.com/bradfitz/latlong"
 )
 
+// ErrSidecarOffline is returned when a sidecar JSON appears to be a
+// cloud-sync placeholder (e.g., OneDrive Files On-Demand) that has not
+// been downloaded locally. Callers should treat this as a hydration
+// problem rather than a corrupt JSON and surface a clear instruction
+// to the user instead of a generic parse error.
+var ErrSidecarOffline = errors.New("sidecar is a cloud placeholder (not downloaded locally)")
+
 // Struct to hold the structure of the JSON metadata
 type imageMetadata struct {
 	Title          string `json:"title"`
@@ -50,11 +58,27 @@ type imageMetadata struct {
 		Longitude float64 `json:"longitude"`
 		Altitude  float64 `json:"altitude"`
 	} `json:"geoData"`
+	GeoDataExif struct {
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+		Altitude  float64 `json:"altitude"`
+	} `json:"geoDataExif"`
 }
 
-// Reads JSON and returns some of its metadata contents using the imageMetadata struct
+// Reads JSON and returns some of its metadata contents using the imageMetadata struct.
+// Returns ErrSidecarOffline if the sidecar is detected as a cloud-sync placeholder
+// rather than a genuine JSON parse error.
 func ReadJsonMetadata(jsonPath string) (imageMetadata, error) {
 	var data imageMetadata
+
+	// Cheap pre-check via os.Stat: on Windows this detects NTFS Cloud Files
+	// placeholders (OneDrive / iCloud) without triggering hydration, and the
+	// zero-size heuristic works cross-platform.
+	if info, err := os.Stat(jsonPath); err == nil {
+		if isCloudPlaceholder(info) || info.Size() == 0 {
+			return data, ErrSidecarOffline
+		}
+	}
 
 	jsonFile, err := os.Open(jsonPath)
 	if err != nil {
@@ -65,6 +89,14 @@ func ReadJsonMetadata(jsonPath string) (imageMetadata, error) {
 	byteValue, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return data, err
+	}
+
+	// Final defense: an otherwise-valid-looking file whose first byte is NUL
+	// is almost certainly a zero-padded cloud placeholder that slipped past
+	// the stat check (some sync clients report a fake size). Any real JSON
+	// starts with '{', '[', whitespace, or a BOM — never NUL.
+	if len(byteValue) == 0 || byteValue[0] == 0x00 {
+		return data, ErrSidecarOffline
 	}
 
 	return data, json.Unmarshal(byteValue, &data)
@@ -140,7 +172,18 @@ func ApplyMetadata(filePath string, meta imageMetadata) error {
 	utcTime := time.Unix(timestampInt, 0).UTC()
 
 	// Determine timezone at the photo's GPS location.
-	photoLoc := getPhotoTimezone(meta.GeoData.Latitude, meta.GeoData.Longitude)
+	lat := meta.GeoData.Latitude
+	lon := meta.GeoData.Longitude
+	alt := meta.GeoData.Altitude
+
+	// Fallback to GeoDataExif if GeoData is empty (Google Takeout quirk)
+	if lat == 0 && lon == 0 {
+		lat = meta.GeoDataExif.Latitude
+		lon = meta.GeoDataExif.Longitude
+		alt = meta.GeoDataExif.Altitude
+	}
+
+	photoLoc := getPhotoTimezone(lat, lon)
 	localTime := utcTime.In(photoLoc)
 	_, offsetSec := localTime.Zone()
 	offsetStr := formatTimezoneOffset(offsetSec)
@@ -173,9 +216,7 @@ func ApplyMetadata(filePath string, meta imageMetadata) error {
 
 	// If geodata exists, add it to args
 	// EXIF uses N E S W for geodata
-	if meta.GeoData.Latitude != 0 && meta.GeoData.Longitude != 0 {
-		lat, lon := meta.GeoData.Latitude, meta.GeoData.Longitude
-
+	if lat != 0 && lon != 0 {
 		latRef, lonRef := "N", "E"
 		if lat < 0 {
 			latRef = "S"
@@ -189,7 +230,7 @@ func ApplyMetadata(filePath string, meta imageMetadata) error {
 			fmt.Sprintf("-GPSLatitudeRef=%s", latRef),
 			fmt.Sprintf("-GPSLongitude=%f", math.Abs(lon)),
 			fmt.Sprintf("-GPSLongitudeRef=%s", lonRef),
-			fmt.Sprintf("-GPSAltitude=%f", meta.GeoData.Altitude),
+			fmt.Sprintf("-GPSAltitude=%f", alt),
 		)
 	}
 

--- a/internal/fixer/offline_other.go
+++ b/internal/fixer/offline_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+/*
+GoogleTakeoutFixer - A tool to easily clean and organize Google Photos Takeout exports
+Copyright (C) 2026 feloex
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package fixer
+
+import "os"
+
+// isCloudPlaceholder reports whether info describes a cloud-sync
+// placeholder. Cloud-file attributes are OS-specific: on non-Windows
+// platforms this is a stub that always returns false, and callers
+// fall back to the zero-size heuristic.
+func isCloudPlaceholder(info os.FileInfo) bool {
+	return false
+}

--- a/internal/fixer/offline_windows.go
+++ b/internal/fixer/offline_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+/*
+GoogleTakeoutFixer - A tool to easily clean and organize Google Photos Takeout exports
+Copyright (C) 2026 feloex
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package fixer
+
+import (
+	"os"
+	"syscall"
+)
+
+// NTFS Cloud Files attributes used by OneDrive Files On-Demand,
+// iCloud, and similar cloud-sync providers. A file with any of these
+// attributes set is a placeholder whose contents are not available
+// locally without triggering a network download.
+//
+// syscall exposes FILE_ATTRIBUTE_OFFLINE but not the Cloud Files API
+// attributes, so we define them here.
+const (
+	fileAttributeOffline            = 0x1000
+	fileAttributeRecallOnOpen       = 0x40000
+	fileAttributeRecallOnDataAccess = 0x400000
+)
+
+// isCloudPlaceholder reports whether info describes a file that is a
+// cloud-sync placeholder not fully present on the local disk. Callers
+// should treat a true result as "skip and instruct the user to hydrate".
+//
+// Important: checking these attributes via os.Stat does NOT trigger a
+// download — only reading the file content does.
+func isCloudPlaceholder(info os.FileInfo) bool {
+	attrs, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	if !ok {
+		return false
+	}
+	const mask = fileAttributeOffline | fileAttributeRecallOnOpen | fileAttributeRecallOnDataAccess
+	return attrs.FileAttributes&mask != 0
+}

--- a/internal/fixer/scanner.go
+++ b/internal/fixer/scanner.go
@@ -1,0 +1,374 @@
+/*
+GoogleTakeoutFixer - A tool to easily clean and organize Google Photos Takeout exports
+Copyright (C) 2026 feloex
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package fixer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type UnmatchedFile struct {
+	MediaPath    string
+	Dir          string
+	MediaName    string
+	JsonsInDir   []string // all .json files in the same directory
+	HasPartner   bool     // video has an image partner with sidecar
+	DebugInfo    string   // verbose diagnostic info
+}
+
+type ScanResult struct {
+	TotalMedia     int
+	TotalMatched   int
+	TotalUnmatched int
+	LimitReached   bool
+	Limit          int
+	Unmatched      []UnmatchedFile
+}
+
+// Scan walks a Google Takeout directory and reports all media files
+// that have no matching .json sidecar. This helps discover naming
+// patterns that FindSidecar doesn't handle yet.
+func Scan(sourcePath string, limit int, verbose bool) (*ScanResult, error) {
+	fileInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access path: %w", err)
+	}
+	if !fileInfo.IsDir() {
+		return nil, fmt.Errorf("source path is not a directory: %s", sourcePath)
+	}
+
+	result := &ScanResult{}
+
+	// Collect directories to scan: the root dir itself + all subdirectories
+	type scanDir struct {
+		path string
+		name string
+	}
+	dirsToScan := []scanDir{{path: sourcePath, name: filepath.Base(sourcePath)}}
+
+	subdirs, err := DiscoverDirs(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("error discovering directories: %w", err)
+	}
+	for _, d := range subdirs {
+		dirsToScan = append(dirsToScan, scanDir{
+			path: filepath.Join(sourcePath, d.Name()),
+			name: d.Name(),
+		})
+	}
+
+scanning:
+	for _, dir := range dirsToScan {
+		files, err := os.ReadDir(dir.path)
+		if err != nil {
+			Log(LoggerWarn, "Cannot read directory %s: %v", dir.path, err)
+			continue
+		}
+
+		// Collect all json files in this directory
+		var jsonsInDir []string
+		for _, f := range files {
+			if !f.IsDir() && strings.HasSuffix(strings.ToLower(f.Name()), ".json") {
+				jsonsInDir = append(jsonsInDir, f.Name())
+			}
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+
+			filePath := filepath.Join(dir.path, f.Name())
+			if !IsMediaFile(filePath) {
+				continue
+			}
+
+			result.TotalMedia++
+
+			if limit > 0 && result.TotalMedia > limit {
+				result.TotalMedia-- // don't count the one that exceeded
+				result.LimitReached = true
+				result.Limit = limit
+				break scanning
+			}
+
+			sidecarPath, err := FindSidecar(filePath)
+			if err != nil {
+				Log(LoggerWarn, "Error checking sidecar for %s: %v", filePath, err)
+				continue
+			}
+
+			if sidecarPath != "" {
+				result.TotalMatched++
+				continue
+			}
+
+			// For videos, check if a partner image has a sidecar
+			hasPartner := false
+			if IsVideoFile(filePath) {
+				partner, err := FindImagePartner(filePath)
+				if err == nil && partner != "" {
+					ps, err := FindSidecar(partner)
+					if err == nil && ps != "" {
+						hasPartner = true
+					}
+				}
+			}
+
+			if hasPartner {
+				result.TotalMatched++
+				continue
+			}
+
+			// Find candidate .json files that look related to this media file
+			candidates := findCandidateJsons(f.Name(), jsonsInDir)
+
+			debugInfo := ""
+			if verbose {
+				debugInfo = buildDebugInfo(f.Name(), jsonsInDir)
+			}
+
+			result.Unmatched = append(result.Unmatched, UnmatchedFile{
+				MediaPath:  filePath,
+				Dir:        dir.name,
+				MediaName:  f.Name(),
+				JsonsInDir: candidates,
+				HasPartner: false,
+				DebugInfo:  debugInfo,
+			})
+		}
+	}
+
+	result.TotalUnmatched = len(result.Unmatched)
+
+	// Sort unmatched by directory then filename
+	sort.Slice(result.Unmatched, func(i, j int) bool {
+		if result.Unmatched[i].Dir != result.Unmatched[j].Dir {
+			return result.Unmatched[i].Dir < result.Unmatched[j].Dir
+		}
+		return result.Unmatched[i].MediaName < result.Unmatched[j].MediaName
+	})
+
+	return result, nil
+}
+
+// buildDebugInfo generates byte-level diagnostic info for an unmatched media file
+func buildDebugInfo(mediaName string, jsonsInDir []string) string {
+	var sb strings.Builder
+
+	mediaLower := strings.ToLower(mediaName)
+	base := strings.TrimSuffix(mediaName, filepath.Ext(mediaName))
+	ext := strings.ToLower(filepath.Ext(mediaName))
+
+	sb.WriteString(fmt.Sprintf("    [DEBUG] media=%q len=%d bytes\n", mediaName, len(mediaName)))
+	sb.WriteString(fmt.Sprintf("    [DEBUG] base=%q ext=%q\n", base, ext))
+	sb.WriteString(fmt.Sprintf("    [DEBUG] media hex: %x\n", []byte(mediaName)))
+
+	// Show supplemental candidate that Layer 1 would compute
+	const supplementalSuffix = ".supplemental-metadata"
+	available := 51 - len(mediaLower) - len(".json")
+	sb.WriteString(fmt.Sprintf("    [DEBUG] supplemental available=%d\n", available))
+	if available > 0 {
+		suffixLen := len(supplementalSuffix)
+		if available < suffixLen {
+			suffixLen = available
+		}
+		candidate := mediaLower + supplementalSuffix[:suffixLen] + ".json"
+		sb.WriteString(fmt.Sprintf("    [DEBUG] supplemental candidate=%q len=%d\n", candidate, len(candidate)))
+		sb.WriteString(fmt.Sprintf("    [DEBUG] candidate hex: %x\n", []byte(candidate)))
+
+		// Check against all jsons
+		for _, j := range jsonsInDir {
+			jLower := strings.ToLower(j)
+			if jLower == candidate {
+				sb.WriteString(fmt.Sprintf("    [DEBUG] MATCH FOUND but FindSidecar missed it: %q\n", j))
+			}
+			// Show hex of closest candidate
+			if strings.Contains(strings.ToLower(j), strings.ToLower(base)[:10]) && strings.HasSuffix(jLower, ".json") {
+				sb.WriteString(fmt.Sprintf("    [DEBUG] json=%q len=%d hex: %x\n", j, len(j), []byte(j)))
+				if len(jLower) == len(candidate) {
+					for i := 0; i < len(candidate); i++ {
+						if candidate[i] != jLower[i] {
+							sb.WriteString(fmt.Sprintf("    [DEBUG] BYTE DIFF at pos %d: candidate=0x%02x json=0x%02x\n", i, candidate[i], jLower[i]))
+						}
+					}
+				} else {
+					sb.WriteString(fmt.Sprintf("    [DEBUG] LENGTH DIFF: candidate=%d json=%d\n", len(candidate), len(jLower)))
+				}
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+// findCandidateJsons returns .json files that look like they could be related
+// to the given media file based on shared prefix or substring matching.
+func findCandidateJsons(mediaName string, jsonsInDir []string) []string {
+	base := strings.TrimSuffix(mediaName, filepath.Ext(mediaName))
+	baseLower := strings.ToLower(base)
+
+	// Use a short prefix for fuzzy matching (first 10 chars or whole name)
+	shortPrefix := baseLower
+	if len(shortPrefix) > 10 {
+		shortPrefix = shortPrefix[:10]
+	}
+
+	var candidates []string
+	for _, j := range jsonsInDir {
+		jLower := strings.ToLower(j)
+		jsonBase := strings.TrimSuffix(jLower, ".json")
+
+		// Check if json name contains significant part of the media name or vice versa
+		if strings.HasPrefix(jLower, shortPrefix) ||
+			strings.Contains(jsonBase, baseLower) ||
+			strings.Contains(baseLower, strings.TrimSuffix(jsonBase, filepath.Ext(jsonBase))) {
+			candidates = append(candidates, j)
+		}
+	}
+
+	return candidates
+}
+
+// FormatScanResult produces a human-readable report of the scan results.
+func FormatScanResult(result *ScanResult) string {
+	var sb strings.Builder
+
+	sb.WriteString("=== Google Takeout Scan Report ===\n\n")
+	if result.LimitReached {
+		sb.WriteString(fmt.Sprintf("(scanned first %d media files)\n\n", result.Limit))
+	}
+	sb.WriteString(fmt.Sprintf("Total media files:   %d\n", result.TotalMedia))
+	sb.WriteString(fmt.Sprintf("Matched (sidecar):   %d\n", result.TotalMatched))
+	sb.WriteString(fmt.Sprintf("Unmatched:           %d\n", result.TotalUnmatched))
+
+	if result.TotalMedia > 0 {
+		pct := float64(result.TotalMatched) / float64(result.TotalMedia) * 100
+		sb.WriteString(fmt.Sprintf("Match rate:          %.1f%%\n", pct))
+	}
+
+	if result.TotalUnmatched == 0 {
+		sb.WriteString("\nAll media files have matching sidecars!\n")
+		return sb.String()
+	}
+
+	sb.WriteString(fmt.Sprintf("\n--- Unmatched Files (%d) ---\n", result.TotalUnmatched))
+
+	currentDir := ""
+	for _, u := range result.Unmatched {
+		if u.Dir != currentDir {
+			currentDir = u.Dir
+			sb.WriteString(fmt.Sprintf("\n[%s]\n", currentDir))
+		}
+
+		sb.WriteString(fmt.Sprintf("  %s\n", u.MediaName))
+		if len(u.JsonsInDir) > 0 {
+			sb.WriteString("    candidate jsons:\n")
+			for _, j := range u.JsonsInDir {
+				sb.WriteString(fmt.Sprintf("      - %s\n", j))
+			}
+		} else {
+			sb.WriteString("    (no candidate .json files found)\n")
+		}
+		if u.DebugInfo != "" {
+			sb.WriteString(u.DebugInfo)
+		}
+	}
+
+	// Summary of naming patterns
+	sb.WriteString("\n--- Pattern Analysis ---\n")
+	patterns := analyzePatterns(result.Unmatched)
+	for _, p := range patterns {
+		sb.WriteString(fmt.Sprintf("  %s (%d files)\n", p.Description, p.Count))
+		if len(p.Examples) > 0 {
+			for _, ex := range p.Examples {
+				sb.WriteString(fmt.Sprintf("    e.g. %s\n", ex))
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+type patternInfo struct {
+	Description string
+	Count       int
+	Examples    []string
+}
+
+func analyzePatterns(unmatched []UnmatchedFile) []patternInfo {
+	categories := map[string]*patternInfo{
+		"no_json":         {Description: "No .json files in directory at all"},
+		"has_candidates":  {Description: "Has candidate .json but FindSidecar didn't match"},
+		"no_candidates":   {Description: "Has .json files in dir but none look related"},
+		"edited":          {Description: "Contains '-edited' in name"},
+		"duplicate":       {Description: "Contains '(N)' duplicate marker"},
+		"long_name":       {Description: "Filename >= 40 chars (potential truncation issue)"},
+		"special_chars":   {Description: "Contains special characters (spaces, unicode, etc.)"},
+	}
+
+	for _, u := range unmatched {
+		base := strings.TrimSuffix(u.MediaName, filepath.Ext(u.MediaName))
+
+		if len(u.JsonsInDir) == 0 {
+			addToPattern(categories["no_json"], u.MediaName)
+		} else if len(u.JsonsInDir) > 0 {
+			// There are candidate jsons
+			addToPattern(categories["has_candidates"], u.MediaName)
+		} else {
+			addToPattern(categories["no_candidates"], u.MediaName)
+		}
+
+		if strings.Contains(strings.ToLower(base), "-edited") {
+			addToPattern(categories["edited"], u.MediaName)
+		}
+		if strings.ContainsAny(base, "()") {
+			addToPattern(categories["duplicate"], u.MediaName)
+		}
+		if len(base) >= 40 {
+			addToPattern(categories["long_name"], u.MediaName)
+		}
+		if strings.ContainsAny(base, " _~#&@!") {
+			addToPattern(categories["special_chars"], u.MediaName)
+		}
+	}
+
+	var result []patternInfo
+	for _, p := range categories {
+		if p.Count > 0 {
+			result = append(result, *p)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Count > result[j].Count
+	})
+
+	return result
+}
+
+func addToPattern(p *patternInfo, example string) {
+	p.Count++
+	if len(p.Examples) < 3 {
+		p.Examples = append(p.Examples, example)
+	}
+}

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Build GoogleTakeoutFixer binaries on Windows.
+
+.DESCRIPTION
+    Locates GCC (via scoop mingw or PATH) and compiles both the GUI and CLI
+    binaries using CGO. Requires Go and mingw to be installed.
+
+    Install prerequisites:
+        scoop install go mingw
+
+.PARAMETER Target
+    Which binary to build: "gui", "cli", or "all" (default).
+
+.PARAMETER OutDir
+    Directory to write the binaries to. Defaults to the project root.
+
+.EXAMPLE
+    .\scripts\build-windows.ps1
+
+.EXAMPLE
+    .\scripts\build-windows.ps1 -Target cli
+#>
+param(
+    [ValidateSet("gui","cli","all")]
+    [string]$Target = "all",
+
+    [string]$OutDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+$projectRoot = Split-Path -Parent $PSScriptRoot
+
+if ($OutDir -eq "") { $OutDir = $projectRoot }
+
+# --- Locate GCC ---
+$gcc = Get-Command gcc -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+if (-not $gcc) {
+    # Try scoop mingw
+    $scoopMingw = Join-Path $env:USERPROFILE "scoop\apps\mingw\current\bin\gcc.exe"
+    if (Test-Path $scoopMingw) {
+        $gcc = $scoopMingw
+    }
+}
+if (-not $gcc) {
+    Write-Host "[ERROR] GCC not found. Install via: scoop install mingw" -ForegroundColor Red
+    exit 1
+}
+Write-Host "GCC : $gcc" -ForegroundColor Gray
+
+# --- Locate Go ---
+$go = Get-Command go -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+if (-not $go) {
+    Write-Host "[ERROR] Go not found. Install via: scoop install go" -ForegroundColor Red
+    exit 1
+}
+$goVersion = & $go version
+Write-Host "Go  : $goVersion" -ForegroundColor Gray
+Write-Host "Out : $OutDir" -ForegroundColor Gray
+Write-Host ""
+
+$env:CGO_ENABLED = "1"
+$env:CC = $gcc
+
+function Invoke-Build {
+    param([string]$name, [string]$outFile, [string]$ldflags)
+
+    Write-Host "Building $name..." -ForegroundColor Cyan
+    $start = Get-Date
+    & $go build -ldflags $ldflags -o $outFile ./cmd/main.go
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[ERROR] Build failed for $name (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    $elapsed = [math]::Round(((Get-Date) - $start).TotalSeconds, 1)
+    $size = [math]::Round((Get-Item $outFile).Length / 1MB, 1)
+    Write-Host "  -> $outFile ($size MB, ${elapsed}s)" -ForegroundColor Green
+}
+
+Set-Location $projectRoot
+
+if ($Target -eq "gui" -or $Target -eq "all") {
+    Invoke-Build -name "GoogleTakeoutFixer.exe (GUI)" `
+                 -outFile (Join-Path $OutDir "GoogleTakeoutFixer.exe") `
+                 -ldflags "-s -w -H=windowsgui"
+}
+
+if ($Target -eq "cli" -or $Target -eq "all") {
+    Invoke-Build -name "GoogleTakeoutFixerCLI.exe (CLI)" `
+                 -outFile (Join-Path $OutDir "GoogleTakeoutFixerCLI.exe") `
+                 -ldflags "-s -w"
+}
+
+Write-Host ""
+Write-Host "Done." -ForegroundColor Green

--- a/scripts/migrate-takeout-batches.ps1
+++ b/scripts/migrate-takeout-batches.ps1
@@ -119,7 +119,9 @@ if ($FixerExe -ne "" -and (Test-Path $FixerExe)) {
 }
 
 # 2. Load state and ensure folders exist
-$progress = if (Test-Path $stateFile) { Get-Content $stateFile | ConvertFrom-Json } else { @{ completed = @() } }
+$progress = if (Test-Path $stateFile) { Get-Content $stateFile | ConvertFrom-Json } else { @{ completed = @(); completedWithWarnings = @() } }
+# Ensure the completedWithWarnings field exists in older state files
+if ($null -eq $progress.completedWithWarnings) { $progress | Add-Member -NotePropertyName completedWithWarnings -NotePropertyValue @() }
 if (!(Test-Path $tempBase)) { New-Item -ItemType Directory -Path $tempBase | Out-Null }
 if (!(Test-Path $rawPath)) { New-Item -ItemType Directory -Path $rawPath | Out-Null }
 if (!(Test-Path $stagingPath)) { New-Item -ItemType Directory -Path $stagingPath | Out-Null }
@@ -163,7 +165,8 @@ while ($keepRunning) {
     Write-Host "===============================================" -ForegroundColor Cyan
 
     $allFolders = Get-ChildItem -Path $SourceBase -Directory | Select-Object -ExpandProperty Name
-    $pendingFolders = $allFolders | Where-Object { $_ -notin $progress.completed }
+    $doneFolders = @($progress.completed) + @($progress.completedWithWarnings)
+    $pendingFolders = $allFolders | Where-Object { $_ -notin $doneFolders }
 
     if ($pendingFolders.Count -eq 0) {
         Write-Host "Done! All folders have been processed." -ForegroundColor Green
@@ -218,6 +221,7 @@ while ($keepRunning) {
     }
 
     Write-Host "`n>>> PROCESSING: $selectedFolder (space approved)" -ForegroundColor White -BackgroundColor Blue
+    $batchHadWarnings = $false
 
     # --- STEP 1: COPY FROM ONEDRIVE (HYDRATE) ---
     # robocopy is the correct tool here: reading each file forces OneDrive to
@@ -393,9 +397,9 @@ public class Win32FileAttr {
         Set-Location $ProjectRoot
         try {
             if ($useExe) {
-                & $FixerExe @fixerArgs 2>&1 | Tee-Object -LiteralPath $batchLogFile -Append
+                & $FixerExe @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
             } else {
-                & go run ./cmd @fixerArgs 2>&1 | Tee-Object -LiteralPath $batchLogFile -Append
+                & go run ./cmd @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
             }
         } finally {
             Set-Location $oldDir
@@ -406,6 +410,11 @@ public class Win32FileAttr {
 
         if ($LASTEXITCODE -eq 0) {
             $processedOk = $true
+        } elseif ($LASTEXITCODE -eq 2) {
+            # Exit code 2 = completed with warnings (no errors, but some files skipped)
+            $processedOk = $true
+            $batchHadWarnings = $true
+            Write-Host "  Fixer completed with warnings (exit code 2). Review the log." -ForegroundColor Yellow
         } else {
             Write-Host "Fixer failed (exit code $LASTEXITCODE). See log above for details." -ForegroundColor Red
         }
@@ -416,7 +425,17 @@ public class Win32FileAttr {
     # --- STEP 3: RELEASE RAW + MOVE STAGING -> PROCESSED ---
     Write-Host "`n[3/3] Releasing Raw and preparing batch for upload..." -ForegroundColor Cyan
     if (!$DryRun) {
-        if (Test-Path -LiteralPath $currentRaw) { Remove-Item -LiteralPath $currentRaw -Recurse -Force }
+        if (Test-Path -LiteralPath $currentRaw) {
+            # Brief wait in case the fixer process still holds file handles.
+            Start-Sleep -Seconds 2
+            try {
+                Remove-Item -LiteralPath $currentRaw -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Host "  [WARN] Could not delete Raw folder (file in use?): $_" -ForegroundColor Yellow
+                Write-Host "  Raw\$selectedFolder will be cleaned up on the next run." -ForegroundColor Yellow
+                $batchHadWarnings = $true
+            }
+        }
 
         if (Test-Path -LiteralPath $currentStaging) {
             # Disambiguate if Processed already has this batch name
@@ -440,14 +459,22 @@ public class Win32FileAttr {
         }
     }
 
-    # Mark as dispatched (processed + waiting for manual upload) so it
-    # isn't picked up again on the next iteration.
-    if ($selectedFolder -notin $progress.completed) {
-        $progress.completed += $selectedFolder
-        Save-State
+    # Mark as dispatched so it isn't picked up again on the next iteration.
+    # Batches with non-fatal warnings go to completedWithWarnings for review;
+    # clean batches go to completed.
+    if ($batchHadWarnings) {
+        if ($selectedFolder -notin $progress.completedWithWarnings) {
+            $progress.completedWithWarnings += $selectedFolder
+            Save-State
+        }
+        Write-Host "`nBatch '$selectedFolder' dispatched with warnings — review the log." -ForegroundColor Yellow
+    } else {
+        if ($selectedFolder -notin $progress.completed) {
+            $progress.completed += $selectedFolder
+            Save-State
+        }
+        Write-Host "`nBatch '$selectedFolder' dispatched." -ForegroundColor Green
     }
-
-    Write-Host "`nBatch '$selectedFolder' dispatched." -ForegroundColor Green
     Start-Sleep -Seconds 2
 }
 

--- a/scripts/migrate-takeout-batches.ps1
+++ b/scripts/migrate-takeout-batches.ps1
@@ -127,7 +127,21 @@ if (!(Test-Path $rawPath)) { New-Item -ItemType Directory -Path $rawPath | Out-N
 if (!(Test-Path $stagingPath)) { New-Item -ItemType Directory -Path $stagingPath | Out-Null }
 if (!(Test-Path $processedPath)) { New-Item -ItemType Directory -Path $processedPath | Out-Null }
 
-function Save-State { $progress | ConvertTo-Json -Depth 5 | Set-Content $stateFile }
+function Save-State { $script:progress | ConvertTo-Json -Depth 5 | Set-Content $stateFile }
+
+function Mark-Completed($folder) {
+    if ($folder -notin $script:progress.completed) {
+        $script:progress.completed = @($script:progress.completed) + @($folder)
+    }
+    Save-State
+}
+
+function Mark-CompletedWithWarnings($folder) {
+    if ($folder -notin $script:progress.completedWithWarnings) {
+        $script:progress.completedWithWarnings = @($script:progress.completedWithWarnings) + @($folder)
+    }
+    Save-State
+}
 
 # Compute a folder's size WITHOUT hydrating its contents. Using the
 # Scripting.FileSystemObject COM component reads the NTFS metadata
@@ -159,14 +173,37 @@ if (!(Get-Command exiftool -ErrorAction SilentlyContinue)) {
 
 # 4. Main loop
 $keepRunning = $true
+$lastSelectedFolder = $null
+$sameFolderRetries = 0
 while ($keepRunning) {
     Write-Host "`n===============================================" -ForegroundColor Cyan
     Write-Host "   Google Photos Automatic Migration Queue     " -ForegroundColor Cyan
     Write-Host "===============================================" -ForegroundColor Cyan
 
-    $allFolders = Get-ChildItem -Path $SourceBase -Directory | Select-Object -ExpandProperty Name
-    $doneFolders = @($progress.completed) + @($progress.completedWithWarnings)
-    $pendingFolders = $allFolders | Where-Object { $_ -notin $doneFolders }
+    # Enumerate source folders using -LiteralPath-equivalent semantics. Trim any
+    # trailing whitespace from the names and drop empty strings, so that invisible
+    # filesystem artifacts (e.g. a "Z " with trailing space that came from an old
+    # OneDrive sync) cannot diverge from what we wrote into the state file.
+    $allFolders = @(
+        Get-ChildItem -LiteralPath $SourceBase -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.Name.Trim() } |
+            Where-Object { $_ -ne "" }
+    )
+
+    # Build a case-insensitive HashSet of "done" folders for reliable lookups
+    # that don't depend on PowerShell's -notin behavior with PSCustomObject arrays.
+    $doneSet = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($n in @($progress.completed))              { if ($n) { [void]$doneSet.Add($n.Trim()) } }
+    foreach ($n in @($progress.completedWithWarnings))  { if ($n) { [void]$doneSet.Add($n.Trim()) } }
+
+    $pendingFolders = @($allFolders | Where-Object { -not $doneSet.Contains($_) })
+
+    Write-Host ("Source folders: {0}  |  Done (clean+warn): {1}  |  Pending: {2}" -f `
+        $allFolders.Count, $doneSet.Count, $pendingFolders.Count) -ForegroundColor Gray
+    if ($pendingFolders.Count -gt 0) {
+        $preview = $pendingFolders | Select-Object -First 5
+        Write-Host ("Next up: {0}" -f ($preview -join " | ")) -ForegroundColor DarkGray
+    }
 
     if ($pendingFolders.Count -eq 0) {
         Write-Host "Done! All folders have been processed." -ForegroundColor Green
@@ -174,6 +211,25 @@ while ($keepRunning) {
     }
 
     $selectedFolder = $pendingFolders[0]
+
+    # Loop guard: if we keep picking the same folder without it moving to
+    # completed, something is silently wrong (state not persisting, name
+    # mismatch, etc.). Abort instead of spinning forever.
+    if ($selectedFolder -eq $lastSelectedFolder) {
+        $sameFolderRetries++
+        if ($sameFolderRetries -ge 3) {
+            Write-Host "`n[ABORT] Loop guard: folder '$selectedFolder' was selected $sameFolderRetries times in a row without leaving pending." -ForegroundColor Red
+            Write-Host "        progress.completed count            : $(@($progress.completed).Count)" -ForegroundColor Yellow
+            Write-Host "        progress.completedWithWarnings count : $(@($progress.completedWithWarnings).Count)" -ForegroundColor Yellow
+            Write-Host "        Is folder in doneSet?                : $($doneSet.Contains($selectedFolder))" -ForegroundColor Yellow
+            Write-Host "        State file: $stateFile" -ForegroundColor Yellow
+            Write-Host "        Inspect the state file and folder name for hidden differences (trailing whitespace, Unicode lookalikes)." -ForegroundColor Yellow
+            break
+        }
+    } else {
+        $lastSelectedFolder = $selectedFolder
+        $sameFolderRetries = 1
+    }
     $sourcePath = Join-Path $SourceBase $selectedFolder
     $currentRaw = Join-Path $rawPath $selectedFolder
     $currentStaging = Join-Path $stagingPath $selectedFolder
@@ -191,7 +247,7 @@ while ($keepRunning) {
 
     $freeSpaceBytes = (Get-PSDrive C).Free
     $freeSpaceGB = [math]::Round($freeSpaceBytes / 1GB, 2)
-
+    Write-Host "Pending batch(es)        : $($pendingFolders.Count)" -ForegroundColor Gray
     Write-Host "Estimated folder size    : $folderSizeGB GB" -ForegroundColor Gray
     Write-Host "Required space (w/ 5%)   : $requiredSpaceGB GB" -ForegroundColor Gray
     Write-Host "Current free space on C: : $freeSpaceGB GB" -ForegroundColor Gray
@@ -207,17 +263,21 @@ while ($keepRunning) {
             Write-Host "Clearing Processed folder to reclaim space..." -ForegroundColor Cyan
             Get-ChildItem -Path $processedPath -Directory | ForEach-Object {
                 Remove-Item -Path $_.FullName -Recurse -Force
-                if ($_.Name -notin $progress.completed) {
-                    $progress.completed += $_.Name
-                }
+                Mark-Completed $_.Name
             }
-            Save-State
             Write-Host "Cleanup done! Recomputing available space..." -ForegroundColor Green
             continue
         } else {
             Write-Host "Paused. Wait for the upload to finish and run the script again." -ForegroundColor Yellow
             break
         }
+    }
+
+    # Skip empty source folders (e.g. placeholder albums in the Takeout export).
+    if ($folderSizeBytes -eq 0) {
+        Write-Host "`n>>> SKIPPING: $selectedFolder (empty folder — nothing to copy)" -ForegroundColor Gray
+        Mark-Completed $selectedFolder
+        continue
     }
 
     Write-Host "`n>>> PROCESSING: $selectedFolder (space approved)" -ForegroundColor White -BackgroundColor Blue
@@ -468,16 +528,10 @@ public class Win32FileAttr {
     # Batches with non-fatal warnings go to completedWithWarnings for review;
     # clean batches go to completed.
     if ($batchHadWarnings) {
-        if ($selectedFolder -notin $progress.completedWithWarnings) {
-            $progress.completedWithWarnings += $selectedFolder
-            Save-State
-        }
+        Mark-CompletedWithWarnings $selectedFolder
         Write-Host "`nBatch '$selectedFolder' dispatched with warnings — review the log." -ForegroundColor Yellow
     } else {
-        if ($selectedFolder -notin $progress.completed) {
-            $progress.completed += $selectedFolder
-            Save-State
-        }
+        Mark-Completed $selectedFolder
         Write-Host "`nBatch '$selectedFolder' dispatched." -ForegroundColor Green
     }
     Start-Sleep -Seconds 2

--- a/scripts/migrate-takeout-batches.ps1
+++ b/scripts/migrate-takeout-batches.ps1
@@ -448,6 +448,11 @@ public class Win32FileAttr {
 
             Move-Item -LiteralPath $currentStaging -Destination $processedPath -Force
             Write-Host "Batch ready in Processed as: $(Split-Path $currentProcessed -Leaf)" -ForegroundColor Green
+        } elseif ($processedOk) {
+            # Fixer exited successfully but created no output folder — the batch
+            # contained no media files (e.g. a Google Takeout "notas" folder).
+            # Not an error: mark as completed and continue.
+            Write-Host "No media files in '$selectedFolder' — skipped (nothing to upload)." -ForegroundColor Gray
         } else {
             Write-Host "`n[!] ERROR: Staging does not contain the expected folder '$selectedFolder'." -ForegroundColor Red
             Write-Host "GoogleTakeoutFixer may have produced a different layout. Current contents of Staging:" -ForegroundColor Yellow

--- a/scripts/migrate-takeout-batches.ps1
+++ b/scripts/migrate-takeout-batches.ps1
@@ -237,8 +237,8 @@ while ($keepRunning) {
     $existingBatchFiles  = 0
     $existingZeroBytes   = 0
     $existingCloudStubs  = 0
-    if (Test-Path $currentRaw) {
-        $existingRaw        = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $currentRaw) {
+        $existingRaw        = Get-ChildItem -LiteralPath $currentRaw -Recurse -File -ErrorAction SilentlyContinue
         $existingBatchFiles = $existingRaw.Count
         $existingZeroBytes  = ($existingRaw | Where-Object { $_.Length -eq 0 }).Count
         $existingCloudStubs = ($existingRaw | Where-Object { ([int]$_.Attributes -band $cloudAttrMask) -ne 0 }).Count
@@ -250,7 +250,7 @@ while ($keepRunning) {
         if ($existingZeroBytes -gt 0 -or $existingCloudStubs -gt 0) {
             $reason = if ($existingCloudStubs -gt 0) { "$existingCloudStubs file(s) with cloud attributes (from old robocopy run)" } else { "$existingZeroBytes zero-byte file(s)" }
             Write-Host "`n[1/3] Raw\$selectedFolder has $reason. Re-copying with fixed flags..." -ForegroundColor Yellow
-            Remove-Item -Path $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
         } else {
             Write-Host "`n[1/3] Copying from OneDrive to local disk (Raw)..." -ForegroundColor Cyan
         }
@@ -267,8 +267,8 @@ while ($keepRunning) {
 
             while ($job.State -eq "Running") {
                 $bytes = 0
-                if (Test-Path $dst) {
-                    $bytes = (Get-ChildItem $dst -Recurse -File -ErrorAction SilentlyContinue |
+                if (Test-Path -LiteralPath $dst) {
+                    $bytes = (Get-ChildItem -LiteralPath $dst -Recurse -File -ErrorAction SilentlyContinue |
                               Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
                     if ($null -eq $bytes) { $bytes = 0 }
                 }
@@ -285,7 +285,7 @@ while ($keepRunning) {
         Invoke-Robocopy -src $sourcePath -dst $currentRaw -threads 4 -isDryRun $DryRun
 
         if (!$DryRun) {
-            $rawFiles  = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+            $rawFiles  = Get-ChildItem -LiteralPath $currentRaw -Recurse -File -ErrorAction SilentlyContinue
 
             if ($rawFiles.Count -eq 0) {
                 Write-Host "`n[ERROR] Copy produced no files in '$currentRaw'. Aborting." -ForegroundColor Red
@@ -327,7 +327,7 @@ public class Win32FileAttr {
             }
             if ($stripped -gt 0) {
                 Write-Host "  Stripped cloud-sync attributes from $stripped file(s)." -ForegroundColor Gray
-                $rawFiles = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+                $rawFiles = Get-ChildItem -LiteralPath $currentRaw -Recurse -File -ErrorAction SilentlyContinue
             }
 
             $zeroFiles = $rawFiles | Where-Object { $_.Length -eq 0 }
@@ -348,14 +348,14 @@ public class Win32FileAttr {
                     }
                 }
 
-                $rawFiles  = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+                $rawFiles  = Get-ChildItem -LiteralPath $currentRaw -Recurse -File -ErrorAction SilentlyContinue
                 $zeroFiles = $rawFiles | Where-Object { $_.Length -eq 0 }
 
                 if ($zeroFiles.Count -gt 0) {
                     Write-Host "`n[ERROR] $($zeroFiles.Count) file(s) still 0-byte after Copy-Item retry:" -ForegroundColor Red
                     $zeroFiles | ForEach-Object { Write-Host "  $($_.Name)" -ForegroundColor Red }
                     Write-Host "OneDrive may still be downloading. Wait a moment and re-run." -ForegroundColor Yellow
-                    Remove-Item -Path $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
+                    Remove-Item -LiteralPath $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
                     break
                 }
             }
@@ -386,16 +386,16 @@ public class Win32FileAttr {
         # Pipe through Tee-Object so the fixer's stdout/stderr lands both on
         # the console AND in a per-batch log file — PowerShell 7's transcript
         # does not capture external-process output directly.
-        $batchLogFile = Join-Path $ProjectRoot "logs" ("batch-$($selectedFolder -replace '[\\/:*?""<>|]','_')-$(Get-Date -Format 'yyyyMMdd_HHmmss').log")
+        $batchLogFile = Join-Path $ProjectRoot "logs" ("batch-$($selectedFolder -replace '[\\/:*?\[\]""<>|]','_')-$(Get-Date -Format 'yyyyMMdd_HHmmss').log")
         $null = New-Item -ItemType Directory -Path (Join-Path $ProjectRoot "logs") -Force
 
         $oldDir = Get-Location
         Set-Location $ProjectRoot
         try {
             if ($useExe) {
-                & $FixerExe @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
+                & $FixerExe @fixerArgs 2>&1 | Tee-Object -LiteralPath $batchLogFile -Append
             } else {
-                & go run ./cmd @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
+                & go run ./cmd @fixerArgs 2>&1 | Tee-Object -LiteralPath $batchLogFile -Append
             }
         } finally {
             Set-Location $oldDir
@@ -416,23 +416,23 @@ public class Win32FileAttr {
     # --- STEP 3: RELEASE RAW + MOVE STAGING -> PROCESSED ---
     Write-Host "`n[3/3] Releasing Raw and preparing batch for upload..." -ForegroundColor Cyan
     if (!$DryRun) {
-        if (Test-Path $currentRaw) { Remove-Item -Path $currentRaw -Recurse -Force }
+        if (Test-Path -LiteralPath $currentRaw) { Remove-Item -LiteralPath $currentRaw -Recurse -Force }
 
-        if (Test-Path $currentStaging) {
+        if (Test-Path -LiteralPath $currentStaging) {
             # Disambiguate if Processed already has this batch name
-            if (Test-Path $currentProcessed) {
+            if (Test-Path -LiteralPath $currentProcessed) {
                 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
                 $currentProcessed = Join-Path $processedPath "$selectedFolder-$timestamp"
-                Rename-Item -Path $currentStaging -NewName "$selectedFolder-$timestamp"
+                Rename-Item -LiteralPath $currentStaging -NewName "$selectedFolder-$timestamp"
                 $currentStaging = Join-Path $stagingPath "$selectedFolder-$timestamp"
             }
 
-            Move-Item -Path $currentStaging -Destination $processedPath -Force
+            Move-Item -LiteralPath $currentStaging -Destination $processedPath -Force
             Write-Host "Batch ready in Processed as: $(Split-Path $currentProcessed -Leaf)" -ForegroundColor Green
         } else {
             Write-Host "`n[!] ERROR: Staging does not contain the expected folder '$selectedFolder'." -ForegroundColor Red
             Write-Host "GoogleTakeoutFixer may have produced a different layout. Current contents of Staging:" -ForegroundColor Yellow
-            Get-ChildItem $stagingPath -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+            Get-ChildItem -LiteralPath $stagingPath -Directory -ErrorAction SilentlyContinue | ForEach-Object {
                 Write-Host "  - $($_.Name)" -ForegroundColor Yellow
             }
             Write-Host "Fix manually and retry. The batch was NOT marked as completed." -ForegroundColor Red

--- a/scripts/migrate-takeout-batches.ps1
+++ b/scripts/migrate-takeout-batches.ps1
@@ -1,0 +1,455 @@
+<#
+.SYNOPSIS
+    Batch migration pipeline for Google Photos Takeout living on OneDrive.
+
+.DESCRIPTION
+    Iterates over each top-level subfolder of the Takeout source tree and
+    drives a hydrate → fix → release cycle designed to keep the local disk
+    from filling up when the source is stored in OneDrive "Files On-Demand"
+    mode:
+
+        1. Verify there is enough free space on C: for the next batch
+           (2 x folder size + 5% margin). If not, pause and ask the user
+           to confirm the previous upload batch finished, then clean
+           `Processed/` to reclaim space.
+
+        2. robocopy the batch from the OneDrive source to `Raw/` — this
+           forces OneDrive to hydrate the placeholders into real files.
+
+        3. Run GoogleTakeoutFixer on `Raw/{batch}` → `Staging/{batch}`
+           to apply EXIF metadata.
+
+        4. Delete `Raw/{batch}` and move `Staging/{batch}` → `Processed/{batch}`.
+           The user then uploads `Processed/{batch}` to the new Google
+           account via browser, and on the next run the completed folders
+           can be cleaned to free disk space.
+
+    State is persisted in `migration-progress.json` next to this script,
+    so the pipeline is resumable after a crash or reboot.
+
+    The source Takeout tree is treated as READ-ONLY at all times: the
+    script only copies from it, never modifies or deletes.
+
+.PARAMETER DryRun
+    Simulate robocopy with /L and skip the actual fixer invocation. Use
+    this to preview what the next batch would do without touching disk.
+
+.PARAMETER SourceBase
+    Root of the Google Photos Takeout export. Defaults to the OneDrive
+    path used during the 2026 migration.
+
+.PARAMETER ProjectRoot
+    Path to the GoogleTakeoutFixer project (folder containing go.mod).
+    Defaults to the local D:\ repo so the pipeline uses the patched
+    version of the fixer, NOT the stale copy synced into OneDrive.
+
+.PARAMETER FixerExe
+    Path to a pre-built GoogleTakeoutFixer.exe. If provided, the script
+    uses it directly and skips `go run`, which avoids recompilation
+    overhead on every batch.
+
+.EXAMPLE
+    .\migrate-takeout-batches.ps1 -DryRun
+
+.EXAMPLE
+    .\migrate-takeout-batches.ps1 -FixerExe "D:\repos\GoogleTakeoutFixer_Windows_x64\GoogleTakeoutFixer\GoogleTakeoutFixer.exe"
+#>
+param(
+    [Parameter(Mandatory=$false)]
+    [switch]$DryRun = $false,
+
+    [Parameter(Mandatory=$false)]
+    [string]$SourceBase = "C:\Users\alexandre-machado\OneDrive\google takeout\Takeout\Google Photos",
+
+    [Parameter(Mandatory=$false)]
+    [string]$ProjectRoot = "D:\repos\GoogleTakeoutFixer_Windows_x64\GoogleTakeoutFixer",
+
+    [Parameter(Mandatory=$false)]
+    [string]$FixerExe = ""
+)
+
+$scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$tempBase = "C:\MigrationTemp"
+$rawPath = Join-Path $tempBase "Raw"
+$stagingPath = Join-Path $tempBase "Staging"
+$processedPath = Join-Path $tempBase "Processed"
+$stateFile = Join-Path $scriptPath "migration-progress.json"
+
+# Begin transcript: captures all console output (including fixer stdout/stderr)
+# to a timestamped file next to this script. Survives crashes and can be
+# reviewed after an unattended run.
+$transcriptFile = Join-Path $scriptPath ("migration-transcript-" + (Get-Date -Format "yyyy-MM-dd_HH-mm-ss") + ".log")
+Start-Transcript -Path $transcriptFile -Append | Out-Null
+Write-Host "Transcript: $transcriptFile" -ForegroundColor Gray
+
+if ($DryRun) {
+    Write-Host "!!! DRY RUN MODE ENABLED (SIMULATION) !!!" -ForegroundColor Black -BackgroundColor Yellow
+}
+
+# 1. Validate project root and resolve fixer invocation
+if (!(Test-Path (Join-Path $ProjectRoot "go.mod"))) {
+    Write-Host "[ERROR] Invalid ProjectRoot: '$ProjectRoot' does not contain go.mod." -ForegroundColor Red
+    Write-Host "Pass -ProjectRoot pointing to the local repository root." -ForegroundColor Yellow
+    exit 1
+}
+
+# Prefer a pre-built console-subsystem .exe (no recompilation per batch, stdout/stderr
+# visible in the terminal). GoogleTakeoutFixerCLI.exe is built without -H=windowsgui so
+# its output flows normally. The GUI exe (GoogleTakeoutFixer.exe) uses the Windows GUI
+# subsystem and its output is swallowed when called from PowerShell — don't use it here.
+# Fall back to `go run` if no binary is found.
+$useExe = $false
+if ($FixerExe -eq "") {
+    $cliExe = Join-Path $ProjectRoot "GoogleTakeoutFixerCLI.exe"
+    $guiExe = Join-Path $ProjectRoot "GoogleTakeoutFixer.exe"
+    if (Test-Path $cliExe) {
+        $FixerExe = $cliExe
+    } elseif (Test-Path $guiExe) {
+        Write-Host "WARNING: GoogleTakeoutFixerCLI.exe not found, using GUI binary." -ForegroundColor Yellow
+        Write-Host "Fixer output may not be visible. Build the CLI binary with:" -ForegroundColor Yellow
+        Write-Host "  CGO_ENABLED=1 go build -ldflags '-s -w' -o GoogleTakeoutFixerCLI.exe ./cmd/main.go" -ForegroundColor Yellow
+        $FixerExe = $guiExe
+    }
+}
+if ($FixerExe -ne "" -and (Test-Path $FixerExe)) {
+    $useExe = $true
+    Write-Host "Using pre-built binary: $FixerExe" -ForegroundColor Gray
+} else {
+    Write-Host "No .exe found - falling back to 'go run ./cmd' (slower)." -ForegroundColor Yellow
+}
+
+# 2. Load state and ensure folders exist
+$progress = if (Test-Path $stateFile) { Get-Content $stateFile | ConvertFrom-Json } else { @{ completed = @() } }
+if (!(Test-Path $tempBase)) { New-Item -ItemType Directory -Path $tempBase | Out-Null }
+if (!(Test-Path $rawPath)) { New-Item -ItemType Directory -Path $rawPath | Out-Null }
+if (!(Test-Path $stagingPath)) { New-Item -ItemType Directory -Path $stagingPath | Out-Null }
+if (!(Test-Path $processedPath)) { New-Item -ItemType Directory -Path $processedPath | Out-Null }
+
+function Save-State { $progress | ConvertTo-Json -Depth 5 | Set-Content $stateFile }
+
+# Compute a folder's size WITHOUT hydrating its contents. Using the
+# Scripting.FileSystemObject COM component reads the NTFS metadata
+# directly, whereas Get-ChildItem -Recurse would trigger OneDrive
+# downloads for placeholder files.
+function Get-FolderSize ($path) {
+    $size = 0
+    $fso = New-Object -ComObject Scripting.FileSystemObject
+    if ($fso.FolderExists($path)) {
+        $folder = $fso.GetFolder($path)
+        $size = $folder.Size
+    }
+    return $size
+}
+
+# 3. Configure ExifTool on PATH so the fixer's exec.LookPath finds it.
+# We prefer the one bundled next to the fixer .exe (matches the release
+# layout), otherwise assume it's already on PATH via scoop/winget.
+if ($useExe) {
+    $exifToolDir = Split-Path -Parent $FixerExe
+    if (Test-Path (Join-Path $exifToolDir "exiftool.exe")) {
+        $env:PATH = "$exifToolDir;$env:PATH"
+        Write-Host "ExifTool detected next to the fixer and added to PATH." -ForegroundColor Gray
+    }
+}
+if (!(Get-Command exiftool -ErrorAction SilentlyContinue)) {
+    Write-Host "WARNING: exiftool.exe not found on PATH. Install via 'scoop install exiftool' or place it next to the .exe." -ForegroundColor Yellow
+}
+
+# 4. Main loop
+$keepRunning = $true
+while ($keepRunning) {
+    Write-Host "`n===============================================" -ForegroundColor Cyan
+    Write-Host "   Google Photos Automatic Migration Queue     " -ForegroundColor Cyan
+    Write-Host "===============================================" -ForegroundColor Cyan
+
+    $allFolders = Get-ChildItem -Path $SourceBase -Directory | Select-Object -ExpandProperty Name
+    $pendingFolders = $allFolders | Where-Object { $_ -notin $progress.completed }
+
+    if ($pendingFolders.Count -eq 0) {
+        Write-Host "Done! All folders have been processed." -ForegroundColor Green
+        break
+    }
+
+    $selectedFolder = $pendingFolders[0]
+    $sourcePath = Join-Path $SourceBase $selectedFolder
+    $currentRaw = Join-Path $rawPath $selectedFolder
+    $currentStaging = Join-Path $stagingPath $selectedFolder
+    $currentProcessed = Join-Path $processedPath $selectedFolder
+
+    # --- FREE-SPACE CHECK ---
+    Write-Host "Analyzing next batch: '$selectedFolder'..." -ForegroundColor Gray
+
+    $folderSizeBytes = Get-FolderSize $sourcePath
+    $folderSizeGB = [math]::Round($folderSizeBytes / 1GB, 2)
+
+    # 2x folder size (1x Raw + 1x Staging/Processed) + 5% safety margin
+    $requiredSpaceBytes = ($folderSizeBytes * 2) * 1.05
+    $requiredSpaceGB = [math]::Round($requiredSpaceBytes / 1GB, 2)
+
+    $freeSpaceBytes = (Get-PSDrive C).Free
+    $freeSpaceGB = [math]::Round($freeSpaceBytes / 1GB, 2)
+
+    Write-Host "Estimated folder size    : $folderSizeGB GB" -ForegroundColor Gray
+    Write-Host "Required space (w/ 5%)   : $requiredSpaceGB GB" -ForegroundColor Gray
+    Write-Host "Current free space on C: : $freeSpaceGB GB" -ForegroundColor Gray
+
+    if ($freeSpaceBytes -lt $requiredSpaceBytes) {
+        Write-Host "`n[!] PAUSE: Insufficient space for the next batch." -ForegroundColor Yellow
+        Write-Host "Batch '$selectedFolder' needs $requiredSpaceGB GB, but only $freeSpaceGB GB are free." -ForegroundColor Yellow
+        Write-Host "The 'Processed' folder is full waiting for the browser upload to Google Photos to finish." -ForegroundColor Magenta
+
+        $uploadDone = Read-Host "`nHas the browser upload for previous batches finished? (Y/N to clean and continue)"
+
+        if ($uploadDone -eq "Y" -or $uploadDone -eq "y") {
+            Write-Host "Clearing Processed folder to reclaim space..." -ForegroundColor Cyan
+            Get-ChildItem -Path $processedPath -Directory | ForEach-Object {
+                Remove-Item -Path $_.FullName -Recurse -Force
+                if ($_.Name -notin $progress.completed) {
+                    $progress.completed += $_.Name
+                }
+            }
+            Save-State
+            Write-Host "Cleanup done! Recomputing available space..." -ForegroundColor Green
+            continue
+        } else {
+            Write-Host "Paused. Wait for the upload to finish and run the script again." -ForegroundColor Yellow
+            break
+        }
+    }
+
+    Write-Host "`n>>> PROCESSING: $selectedFolder (space approved)" -ForegroundColor White -BackgroundColor Blue
+
+    # --- STEP 1: COPY FROM ONEDRIVE (HYDRATE) ---
+    # robocopy is the correct tool here: reading each file forces OneDrive to
+    # download its content from the cloud (hydration). The risk is /MT with
+    # too many threads overwhelming the OneDrive download queue, causing some
+    # files to arrive as 0-byte stubs. Strategy:
+    #   • First pass  : /MT:4 (parallel, faster)
+    #   • If 0-bytes  : second pass /MT:1 (sequential, reliable) for those files
+    #   • If still 0  : abort with clear message
+
+    # Skip-copy only when existing Raw files all have real, clean content.
+    # Triggers a fresh copy if: no files exist, any are 0-byte, or any still
+    # carry NTFS cloud-sync attributes (OFFLINE 0x1000, RECALL_ON_DATA_ACCESS
+    # 0x400000) — which means a previous robocopy run propagated OneDrive
+    # placeholder attributes to the destination without stripping them.
+    $cloudAttrMask = 0x1000 -bor 0x40000 -bor 0x400000
+    $existingBatchFiles  = 0
+    $existingZeroBytes   = 0
+    $existingCloudStubs  = 0
+    if (Test-Path $currentRaw) {
+        $existingRaw        = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+        $existingBatchFiles = $existingRaw.Count
+        $existingZeroBytes  = ($existingRaw | Where-Object { $_.Length -eq 0 }).Count
+        $existingCloudStubs = ($existingRaw | Where-Object { ([int]$_.Attributes -band $cloudAttrMask) -ne 0 }).Count
+    }
+
+    if ($existingBatchFiles -gt 0 -and $existingZeroBytes -eq 0 -and $existingCloudStubs -eq 0 -and !$DryRun) {
+        Write-Host "`n[1/3] Raw\$selectedFolder already contains $existingBatchFiles clean file(s) (retry). Skipping copy." -ForegroundColor Yellow
+    } else {
+        if ($existingZeroBytes -gt 0 -or $existingCloudStubs -gt 0) {
+            $reason = if ($existingCloudStubs -gt 0) { "$existingCloudStubs file(s) with cloud attributes (from old robocopy run)" } else { "$existingZeroBytes zero-byte file(s)" }
+            Write-Host "`n[1/3] Raw\$selectedFolder has $reason. Re-copying with fixed flags..." -ForegroundColor Yellow
+            Remove-Item -Path $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
+        } else {
+            Write-Host "`n[1/3] Copying from OneDrive to local disk (Raw)..." -ForegroundColor Cyan
+        }
+
+        function Invoke-Robocopy {
+            param($src, $dst, $threads, $isDryRun)
+            $activity = "[1/3] Downloading '$selectedFolder' (threads: $threads)..."
+            $job = Start-Job -ScriptBlock {
+                param($s, $d, $t, $dry)
+                $args = @($s, $d, "/E", "/R:3", "/W:5", "/MT:$t")
+                if ($dry) { $args += "/L" }
+                & robocopy @args
+            } -ArgumentList $src, $dst, $threads, $isDryRun
+
+            while ($job.State -eq "Running") {
+                $bytes = 0
+                if (Test-Path $dst) {
+                    $bytes = (Get-ChildItem $dst -Recurse -File -ErrorAction SilentlyContinue |
+                              Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                    if ($null -eq $bytes) { $bytes = 0 }
+                }
+                $pct = if ($folderSizeBytes -gt 0) { [math]::Min(99, [int](($bytes / $folderSizeBytes) * 100)) } else { 0 }
+                Write-Progress -Activity $activity -Status "$([math]::Round($bytes/1GB,2)) GB / $folderSizeGB GB" -PercentComplete $pct
+                Start-Sleep -Seconds 2
+            }
+            Write-Progress -Activity $activity -Completed
+            Receive-Job -Job $job -Wait | Out-Null
+            Remove-Job -Job $job
+        }
+
+        # First pass: /MT:4
+        Invoke-Robocopy -src $sourcePath -dst $currentRaw -threads 4 -isDryRun $DryRun
+
+        if (!$DryRun) {
+            $rawFiles  = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+
+            if ($rawFiles.Count -eq 0) {
+                Write-Host "`n[ERROR] Copy produced no files in '$currentRaw'. Aborting." -ForegroundColor Red
+                break
+            }
+
+            # Strip NTFS cloud-sync attributes that robocopy copied from the OneDrive
+            # source (OFFLINE 0x1000, RECALL_ON_OPEN 0x40000, RECALL_ON_DATA_ACCESS
+            # 0x400000). In a non-OneDrive folder these bits are meaningless but would
+            # cause the fixer to wrongly treat a fully-downloaded file as a placeholder.
+            # All other attributes (read-only, compressed, encrypted…) are preserved.
+            #
+            # [System.IO.FileAttributes] only covers the standard .NET subset of NTFS
+            # attribute bits — RECALL_ON_OPEN (0x40000) and RECALL_ON_DATA_ACCESS
+            # (0x400000) are not in that enum, so casting throws. Use the Win32
+            # SetFileAttributes API directly via P/Invoke instead.
+            if (-not ([System.Management.Automation.PSTypeName]'Win32FileAttr').Type) {
+                Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public class Win32FileAttr {
+    [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern bool SetFileAttributes(string lpFileName, uint dwFileAttributes);
+}
+'@
+            }
+            $cloudAttrMask = 0x1000 -bor 0x40000 -bor 0x400000
+            $stripped = 0
+            $rawFiles | ForEach-Object {
+                $raw = [uint32]$_.Attributes
+                if ($raw -band $cloudAttrMask) {
+                    $newAttrs = [uint32]($raw -band (-bnot $cloudAttrMask))
+                    if ([Win32FileAttr]::SetFileAttributes($_.FullName, $newAttrs)) {
+                        $stripped++
+                    } else {
+                        Write-Host "  [WARN] Could not clear cloud attributes on $($_.Name)" -ForegroundColor Yellow
+                    }
+                }
+            }
+            if ($stripped -gt 0) {
+                Write-Host "  Stripped cloud-sync attributes from $stripped file(s)." -ForegroundColor Gray
+                $rawFiles = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+            }
+
+            $zeroFiles = $rawFiles | Where-Object { $_.Length -eq 0 }
+
+            if ($zeroFiles.Count -gt 0) {
+                Write-Host "  $($zeroFiles.Count) file(s) arrived as 0-byte reparse stubs — retrying with Copy-Item (forces content read)..." -ForegroundColor Yellow
+
+                # robocopy with /MT can copy OneDrive reparse-point metadata
+                # instead of content. Copy-Item follows reparse points and reads
+                # actual bytes, guaranteeing hydration without admin rights.
+                foreach ($stub in $zeroFiles) {
+                    $relativePath = $stub.FullName.Substring($currentRaw.Length).TrimStart('\')
+                    $srcFile = Join-Path $sourcePath $relativePath
+                    try {
+                        Copy-Item -LiteralPath $srcFile -Destination $stub.FullName -Force
+                    } catch {
+                        Write-Host "  [WARN] Could not copy $relativePath : $_" -ForegroundColor Yellow
+                    }
+                }
+
+                $rawFiles  = Get-ChildItem $currentRaw -Recurse -File -ErrorAction SilentlyContinue
+                $zeroFiles = $rawFiles | Where-Object { $_.Length -eq 0 }
+
+                if ($zeroFiles.Count -gt 0) {
+                    Write-Host "`n[ERROR] $($zeroFiles.Count) file(s) still 0-byte after Copy-Item retry:" -ForegroundColor Red
+                    $zeroFiles | ForEach-Object { Write-Host "  $($_.Name)" -ForegroundColor Red }
+                    Write-Host "OneDrive may still be downloading. Wait a moment and re-run." -ForegroundColor Yellow
+                    Remove-Item -Path $currentRaw -Recurse -Force -ErrorAction SilentlyContinue
+                    break
+                }
+            }
+
+            Write-Host "$($rawFiles.Count) file(s) copied and verified (all non-zero)." -ForegroundColor Gray
+        }
+    }
+
+    # --- STEP 2: PROCESS (invoke the fixer) ---
+    # Pass $rawPath (the parent) as --input so the fixer discovers $selectedFolder
+    # as a subdirectory to process. Passing $currentRaw directly would make the
+    # fixer treat the album folder as the root and find no subdirectories.
+    # Since Raw is cleaned between batches, only the current batch folder is present.
+    Write-Host "`n[2/3] Processing metadata (Raw\$selectedFolder -> Staging)..." -ForegroundColor Cyan
+    $processedOk = $false
+
+    if (!$DryRun) {
+        $fixerArgs = @(
+            "--input", $rawPath,
+            "--output", $stagingPath,
+            "--month-subfolders",
+            "--restore-mov"
+        )
+
+        # Always run from $ProjectRoot so the fixer writes its logs/ folder
+        # to a known, consistent location regardless of where this script
+        # was launched from.
+        # Pipe through Tee-Object so the fixer's stdout/stderr lands both on
+        # the console AND in a per-batch log file — PowerShell 7's transcript
+        # does not capture external-process output directly.
+        $batchLogFile = Join-Path $ProjectRoot "logs" ("batch-$($selectedFolder -replace '[\\/:*?""<>|]','_')-$(Get-Date -Format 'yyyyMMdd_HHmmss').log")
+        $null = New-Item -ItemType Directory -Path (Join-Path $ProjectRoot "logs") -Force
+
+        $oldDir = Get-Location
+        Set-Location $ProjectRoot
+        try {
+            if ($useExe) {
+                & $FixerExe @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
+            } else {
+                & go run ./cmd @fixerArgs 2>&1 | Tee-Object -FilePath $batchLogFile -Append
+            }
+        } finally {
+            Set-Location $oldDir
+        }
+
+        Write-Host "  Fixer log: $batchLogFile" -ForegroundColor Gray
+        Write-Host "  Detailed log: $ProjectRoot\logs\" -ForegroundColor Gray
+
+        if ($LASTEXITCODE -eq 0) {
+            $processedOk = $true
+        } else {
+            Write-Host "Fixer failed (exit code $LASTEXITCODE). See log above for details." -ForegroundColor Red
+        }
+    } else { $processedOk = $true }
+
+    if (!$processedOk) { break }
+
+    # --- STEP 3: RELEASE RAW + MOVE STAGING -> PROCESSED ---
+    Write-Host "`n[3/3] Releasing Raw and preparing batch for upload..." -ForegroundColor Cyan
+    if (!$DryRun) {
+        if (Test-Path $currentRaw) { Remove-Item -Path $currentRaw -Recurse -Force }
+
+        if (Test-Path $currentStaging) {
+            # Disambiguate if Processed already has this batch name
+            if (Test-Path $currentProcessed) {
+                $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+                $currentProcessed = Join-Path $processedPath "$selectedFolder-$timestamp"
+                Rename-Item -Path $currentStaging -NewName "$selectedFolder-$timestamp"
+                $currentStaging = Join-Path $stagingPath "$selectedFolder-$timestamp"
+            }
+
+            Move-Item -Path $currentStaging -Destination $processedPath -Force
+            Write-Host "Batch ready in Processed as: $(Split-Path $currentProcessed -Leaf)" -ForegroundColor Green
+        } else {
+            Write-Host "`n[!] ERROR: Staging does not contain the expected folder '$selectedFolder'." -ForegroundColor Red
+            Write-Host "GoogleTakeoutFixer may have produced a different layout. Current contents of Staging:" -ForegroundColor Yellow
+            Get-ChildItem $stagingPath -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+                Write-Host "  - $($_.Name)" -ForegroundColor Yellow
+            }
+            Write-Host "Fix manually and retry. The batch was NOT marked as completed." -ForegroundColor Red
+            break
+        }
+    }
+
+    # Mark as dispatched (processed + waiting for manual upload) so it
+    # isn't picked up again on the next iteration.
+    if ($selectedFolder -notin $progress.completed) {
+        $progress.completed += $selectedFolder
+        Save-State
+    }
+
+    Write-Host "`nBatch '$selectedFolder' dispatched." -ForegroundColor Green
+    Start-Sleep -Seconds 2
+}
+
+Stop-Transcript | Out-Null
+Write-Host "`nFull transcript saved to: $transcriptFile" -ForegroundColor Gray


### PR DESCRIPTION
  ## Summary

  This PR adds robustness improvements for real-world Google Takeout migrations
  where the source export lives in OneDrive Files On-Demand, and extends the
  fixer's coverage of media formats found in older Android/iOS exports.

  ### OneDrive cloud placeholder detection
  Files that have not been downloaded locally (OneDrive Files On-Demand) are
  detected via NTFS cloud-sync attributes (`FILE_ATTRIBUTE_OFFLINE`,
  `RECALL_ON_OPEN`, `RECALL_ON_DATA_ACCESS`) on Windows and skipped with a
  clear `[WARN]` message instead of silently producing zero-byte output files.
  The same check is applied to JSON sidecar files, distinguishing placeholder
  failures from genuine parse errors via a new `ErrSidecarOffline` sentinel.

  ### Extended media format support
  Recognized image types now include `.heif`, `.gif`, `.nef`, `.dng`, `.webp`,
  `.bmp`, `.tiff`/`.tif`. Video types now include `.3gp`, `.m4v`, `.wmv`,
  `.flv`. Files with no extension are probed via magic bytes (JPEG, PNG, GIF,
  WebP, HEIC, MP4) and the correct extension is appended to the output.

  ### Improved sidecar matching
  `FindSidecar` now handles the full range of naming patterns produced by Google
  Takeout: `.supplemental-metadata.json` variants, duplicate-numbered files
  (`image(1).jpg`), sidecar names truncated at 51 characters, and `-edited`
  variants including `-edited(N)` combos.

  ### Structured logging
  Worker goroutines now recover from panics with a stack trace. A summary line
  is printed at the end of every run showing processed count, error/warning
  counts, and elapsed time. Error and warning counts use atomic increments, safe
  for the concurrent worker pool.

  ### CLI improvements
  - New `--scan` flag reports media files without a matching sidecar, grouped
    by extension — useful for auditing a Takeout export before a full run.
  - Exit code 1 when any errors occur, enabling scripted/CI use.

  ### Migration pipeline script
  `scripts/migrate-takeout-batches.ps1` automates the hydrate → fix → release
  cycle for large exports in OneDrive, with free-space checks, resumable state,
  per-batch log files, and safe handling of cloud-attribute propagation by
  robocopy.

  ## Test plan
  - [ ] Process a batch folder with OneDrive placeholder files — fixer should
    log `[WARN] ... cloud placeholder ... skipping` and produce no zero-byte output
  - [ ] Process files with no extension — output should have the detected extension
  - [ ] Run `--scan` on a Takeout folder and verify unmatched files are reported
  - [ ] Verify exit code is 1 when errors occur and 0 when clean
  - [ ] Run `migrate-takeout-batches.ps1` on a batch with OneDrive placeholders —
    should strip cloud attributes and process successfully