### PR TITLE
feat: update checker + notification

### DIFF
--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -79,8 +79,12 @@ func Main() {
 
 			updateLink.Refresh()
 
-			w.SetContent(container.NewVBox(
+			// Keep the main content in the center so it resizes properly
+			w.SetContent(container.NewBorder(
 				updateLink,
+				nil,
+				nil,
+				nil,
 				w.Content(),
 			))
 		})

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"image/color"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -58,6 +59,32 @@ func Main() {
 	progressBar := widget.NewProgressBar()
 	var cancelFn context.CancelFunc
 	var cancelButton *widget.Button
+
+	// Update checker
+	go func() {
+		latestVersion, err := version.CheckForUpdates()
+		if err != nil {
+			return
+		}
+		url, err := url.Parse(latestVersion.DownloadURL)
+		if err != nil {
+			return
+		}
+		fyne.Do(func() {
+
+			updateMsg := fmt.Sprintf("New version available: %s", latestVersion.Version)
+			updateLink := widget.NewHyperlink(updateMsg, url)
+			updateLink.Alignment = fyne.TextAlignCenter
+			updateLink.TextStyle = fyne.TextStyle{Bold: true}
+
+			updateLink.Refresh()
+
+			w.SetContent(container.NewVBox(
+				updateLink,
+				w.Content(),
+			))
+		})
+	}()
 
 	// Button for opening file dialog for choosing google takeout path and output path
 	var inputButton *widget.Button
@@ -331,7 +358,6 @@ func Main() {
 	FolderSeperator := container.NewPadded(separator)
 	OptionsSeparator := container.NewPadded(separator)
 
-
 	topContent := container.NewVBox(
 		folderButtons,
 		FolderSeperator,
@@ -342,7 +368,7 @@ func Main() {
 		progressLabel,
 	)
 
-  mainContent := container.NewBorder(
+	mainContent := container.NewBorder(
 		topContent,
 		nil,
 		nil,

--- a/internal/gui/gui.go
+++ b/internal/gui/gui.go
@@ -72,7 +72,7 @@ func Main() {
 		}
 		fyne.Do(func() {
 
-			updateMsg := fmt.Sprintf("New version available: %s", latestVersion.Version)
+			updateMsg := fmt.Sprintf("Download new version: %s", latestVersion.Version)
 			updateLink := widget.NewHyperlink(updateMsg, url)
 			updateLink.Alignment = fyne.TextAlignCenter
 			updateLink.TextStyle = fyne.TextStyle{Bold: true}

--- a/internal/version/checker.go
+++ b/internal/version/checker.go
@@ -1,0 +1,92 @@
+/*
+GoogleTakeoutFixer - A tool to easily clean and organize Google Photos Takeout exports
+Copyright (C) 2026 feloex
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type VersionInfo struct {
+	Version     string `json:"tag_name"`
+	DownloadURL string `json:"html_url"`
+}
+
+const apiUrl = "https://api.github.com/repos/feloex/GoogleTakeoutFixer/releases/latest"
+
+func CheckForUpdates() (VersionInfo, error) {
+
+	currentVersion := Tag
+
+	if currentVersion == "dev" {
+		return VersionInfo{}, fmt.Errorf("Running development version, skipping")
+	}
+
+	latest, err := http.Get(apiUrl)
+
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	var latestVersion VersionInfo
+
+	body, err := io.ReadAll(latest.Body)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	err = json.Unmarshal(body, &latestVersion)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+
+	isNewer := isNewerVersion(currentVersion, latestVersion.Version)
+
+	if !isNewer {
+		return VersionInfo{}, fmt.Errorf("Already using latest version (%s)", Tag)
+	}
+
+	return latestVersion, nil
+}
+
+func isNewerVersion(current, latest string) bool {
+
+	// Remove 'v' prefix if present
+	strings.TrimPrefix(current, "v")
+	strings.TrimPrefix(latest, "v")
+
+	currentParts := strings.Split(current, ".")
+	latestParts := strings.Split(latest, ".")
+
+	// versions *should* have 3 parts
+
+	for i := 0; i < len(currentParts) && i < len(latestParts); i++ {
+		if currentParts[i] < latestParts[i] {
+			return true
+		} else if currentParts[i] > latestParts[i] {
+			return false
+		}
+	}
+
+	return len(latestParts) > len(currentParts)
+
+}

--- a/internal/version/checker.go
+++ b/internal/version/checker.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -46,6 +47,8 @@ func CheckForUpdates() (VersionInfo, error) {
 	if err != nil {
 		return VersionInfo{}, err
 	}
+	// Close the respone body when done
+	defer latest.Body.Close()
 
 	var latestVersion VersionInfo
 
@@ -71,18 +74,23 @@ func CheckForUpdates() (VersionInfo, error) {
 func isNewerVersion(current, latest string) bool {
 
 	// Remove 'v' prefix if present
-	strings.TrimPrefix(current, "v")
-	strings.TrimPrefix(latest, "v")
+	current = strings.TrimPrefix(current, "v")
+	latest = strings.TrimPrefix(latest, "v")
 
 	currentParts := strings.Split(current, ".")
 	latestParts := strings.Split(latest, ".")
 
 	// versions *should* have 3 parts
-
 	for i := 0; i < len(currentParts) && i < len(latestParts); i++ {
-		if currentParts[i] < latestParts[i] {
+		currentNum, err1 := strconv.Atoi(currentParts[i])
+		latestNum, err2 := strconv.Atoi(latestParts[i])
+		if err1 != nil || err2 != nil {
+			return false
+		}
+
+		if currentNum < latestNum {
 			return true
-		} else if currentParts[i] > latestParts[i] {
+		} else if currentNum > latestNum {
 			return false
 		}
 	}


### PR DESCRIPTION
Adds a version checker that compares the current version to the latest release version of this repo using the github API.

To test, change the version in internal/version/version.go to something like `v1.3.0`, which is lower than the current v1.4.0 version. When running the gui you should then see a text, telling you to update. Clicking the text opens the release page.

(TODO: Make visual changes as discussed)